### PR TITLE
Clean up CORS header code

### DIFF
--- a/src/stats/src/main/scala/osmesa/stats/TileLayouts.scala
+++ b/src/stats/src/main/scala/osmesa/stats/TileLayouts.scala
@@ -1,0 +1,15 @@
+package osmesa.stats
+
+import com.typesafe.scalalogging.LazyLogging
+import geotrellis.proj4.WebMercator
+import geotrellis.raster._
+import geotrellis.spark.tiling._
+
+
+object TileLayouts extends LazyLogging {
+  private val layouts: Array[LayoutDefinition] = (0 to 30).map({ n =>
+    ZoomedLayoutScheme.layoutForZoom(n, WebMercator.worldExtent, 256)
+  }).toArray
+
+  def apply(i: Int) = layouts(i)
+}


### PR DESCRIPTION
This PR cleans up some slightly ambiguous code and ensures that CORS headers are uniquely assigned to responses.