### PR TITLE
Version Bumps

### DIFF
--- a/src/ingest/build.sbt
+++ b/src/ingest/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   gtVectorTile exclude("com.google.protobuf", "protobuf-java"),
   "com.google.protobuf" % "protobuf-java" % "2.5.0",
   vectorpipe exclude("com.google.protobuf", "protobuf-java"),
-  geomesaHbaseDatastore,
+  //geomesaHbaseDatastore,
   cats,
   hbaseClient % "provided",
   hbaseCommon % "provided",

--- a/src/project/Version.scala
+++ b/src/project/Version.scala
@@ -1,7 +1,7 @@
 object Version {
   val scala = "2.11.11"
   val osmesa = "0.1.0"
-  val geotrellis = "1.2.0-RC2"
+  val geotrellis = "1.2.0"
   val geomesa = "1.4.0-SNAPSHOT"
   val vectorpipe = "0.2.2" //"1.0.0-SNAPSHOT"
   val decline = "0.4.0-RC1"

--- a/src/project/build.properties
+++ b/src/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.1.1


### PR DESCRIPTION
Most important is the SBT version bump which resolved:

```scala
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: it.geosolutions.imageio-ext#imageio-ext-tiff;1.1.18: java.lang.NullPointerException at sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.getURLInfo(GigahorseUrlHandler.scala:54)
[warn] 	:: it.geosolutions.jaiext.affine#jt-affine;1.0.16: java.lang.NullPointerException at sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.getURLInfo(GigahorseUrlHandler.scala:54)
...
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn] 	Note: Unresolved dependencies path:
[warn] 		it.geosolutions.jaiext.affine:jt-affine:1.0.16
[warn] 		  +- org.geotools:gt-coverage:18.0
[warn] 		  +- org.geotools:gt-process:18.0
[warn] 		  +- org.geotools:gt-process-feature:18.0
[warn] 		  +- org.locationtech.geomesa:geomesa-feature-common_2.11:1.4.0-SNAPSHOT
[warn] 		  +- org.locationtech.geomesa:geomesa-feature-kryo_2.11:1.4.0-SNAPSHOT
[warn] 		  +- org.locationtech.geomesa:geomesa-index-api_2.11:1.4.0-SNAPSHOT
[warn] 		  +- org.locationtech.geomesa:geomesa-process-vector_2.11:1.4.0-SNAPSHOT
[warn] 		  +- org.locationtech.geomesa:geomesa-hbase-datastore_2.11:1.4.0-SNAPSHOT ```