### PR TITLE
Cache improvements

### DIFF
--- a/src/ingest/src/main/scala/osmesa/ingest/Ingest.scala
+++ b/src/ingest/src/main/scala/osmesa/ingest/Ingest.scala
@@ -125,8 +125,9 @@ object IngestApp extends CommandApp(
       val df = ss.read.orc(orc)
 
       val cache = Option(new URI(cacheDir).getScheme) match {
-        case Some("file") => Caching.onFs(cacheDir)
         case Some("s3") => Caching.onS3(cacheDir)
+        // bare paths don't get a scheme
+        case None if Option(cacheDir).isDefined => Caching.onFs(cacheDir)
         case _ => Caching.none
       }
 


### PR DESCRIPTION
Prior to this, cached stages will be run once to populate the cache (triggered by `write`) and once where they're used subsequently.

The alternative to this is to add a `cache` call to the write chain to avoid ORC read overhead, but we've seen problems with `cache` on larger stages where the job eventually fails.

This also fixes the local FS cache implementation.