### PR TITLE
Add gzip compression on write to S3

### DIFF
--- a/src/ingest/build.sbt
+++ b/src/ingest/build.sbt
@@ -7,6 +7,7 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.
 dependencyOverrides += "com.fasterxml.jackson.module" % "jackson-module-scala_2.11" % "2.6.7"
 
 libraryDependencies ++= Seq(
+  "org.apache.commons" % "commons-compress" % "1.16.1",
   decline,
   sparkHive % "provided",
   //gtGeomesa exclude("com.google.protobuf", "protobuf-java"),


### PR DESCRIPTION
Tippeanoe's default behavior is to pre-gzip the pbf files as it does a directory-dump of vector tiles. This PR adds similar functionality and sets the appropriate headers on S3.