### PR TITLE
Fix/caching partitions; spatial key printing

### DIFF
--- a/src/ingest/src/main/scala/osmesa/ingest/Ingest.scala
+++ b/src/ingest/src/main/scala/osmesa/ingest/Ingest.scala
@@ -243,7 +243,7 @@ object Ingest extends CommandApp(
 
         // Write out populated spatial keys (use DF for append abilities)
         import ss.implicits._
-        keys.distinct.toDF.repartition(1)
+        keys.distinct.toDF
           .write.format("text").mode(SaveMode.Append).save(s"s3://${bucket}/${prefix}/keys")
 
         GenerateVT.save(GenerateVT.makeVectorTiles(keyedGeoms, layout, layer), zoom, bucket, prefix)

--- a/src/ingest/src/main/scala/osmesa/ingest/Ingest.scala
+++ b/src/ingest/src/main/scala/osmesa/ingest/Ingest.scala
@@ -17,7 +17,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import osmesa.ingest.util.Caching
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.apache.hadoop.fs._
 import vectorpipe._
 
@@ -238,11 +237,8 @@ object Ingest extends CommandApp(
       val layoutScheme = ZoomedLayoutScheme(WebMercator, 512)
 
 
-      val s3client = AmazonS3ClientBuilder.defaultClient()
-
       def build[G <: Geometry](keyedGeoms: RDD[(SpatialKey, (SpatialKey, GenerateVT.VTF[G]))], layoutLevel: LayoutLevel): Unit = {
         val LayoutLevel(zoom, layout) = layoutLevel
-        val objects = s3client.listObjects(bucket, prefix).getObjectSummaries
         val keys = keyedGeoms.map({sk => s"${sk._1.col}/${sk._1.row}"})
 
         // Write out populated spatial keys (use DF for append abilities)

--- a/src/ingest/src/main/scala/osmesa/ingest/util/Caching.scala
+++ b/src/ingest/src/main/scala/osmesa/ingest/util/Caching.scala
@@ -28,7 +28,7 @@ class S3Caching(cacheDir: String) extends Caching {
     if (s3exists(filename)) {
       ss.read.orc(fileUri(filename))
     } else {
-      sparkjob.repartition(1).write.format("orc").save(fileUri(filename))
+      sparkjob.repartition(500).write.format("orc").save(fileUri(filename))
       sparkjob
     }
   }


### PR DESCRIPTION
This PR addresses two issues. Spatial keys are now appended so that multiple jobs can safely be run (useful for bbox vector tile construction). The PR also gives a sensible 500 partitions to the job of caching out work - this should *significantly* improve performance of reads and writes.