### PR TITLE
Simplify offset handling + parallelize reads

### DIFF
--- a/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffMicroBatchReader.scala
@@ -19,20 +19,17 @@ import osmesa.common.model.{
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
-case class AugmentedDiffStreamBatchTask(baseURI: URI,
-                                        start: Int,
-                                        end: Int)
+case class AugmentedDiffStreamBatchTask(baseURI: URI, sequence: Int)
     extends DataReaderFactory[Row] {
   override def createDataReader(): DataReader[Row] =
-    new AugmentedDiffStreamBatchReader(baseURI, start, end)
+    new AugmentedDiffStreamBatchReader(baseURI, sequence)
 }
 
-class AugmentedDiffStreamBatchReader(baseURI: URI,
-                                     start: Int,
-                                     end: Int)
+class AugmentedDiffStreamBatchReader(baseURI: URI, sequence: Int)
     extends ReplicationStreamBatchReader[
       (Option[AugmentedDiffFeature], AugmentedDiffFeature)
-    ](baseURI, start, end) {
+    ](baseURI, sequence) {
+
   override def getSequence(
     baseURI: URI,
     sequence: Int
@@ -122,21 +119,27 @@ class AugmentedDiffMicroBatchReader(options: DataSourceOptions,
                                     checkpointLocation: String)
     extends ReplicationStreamMicroBatchReader(options, checkpointLocation) {
 
-  private def baseURI: URI =
-    options.get("base_uri").asScala.map(new URI(_)).getOrElse(
-        throw new RuntimeException(
-          "base_uri is a required option for augmented-diffs"))
-
   override def getCurrentOffset: SequenceOffset =
     AugmentedDiffSource.createOffsetForCurrentSequence(baseURI)
 
+  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
+    sequenceRange
+      .map(
+        AugmentedDiffStreamBatchTask(baseURI, _)
+          .asInstanceOf[DataReaderFactory[Row]]
+      )
+      .asJava
+
   override def readSchema(): StructType = AugmentedDiffSchema
 
-  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
-    sequenceRange.map(
-        seq =>
-          AugmentedDiffStreamBatchTask(baseURI, seq, seq)
-            .asInstanceOf[DataReaderFactory[Row]]
-    )
-      .asJava
+  private def baseURI: URI =
+    options
+      .get("base_uri")
+      .asScala
+      .map(new URI(_))
+      .getOrElse(
+        throw new RuntimeException(
+          "base_uri is a required option for augmented-diffs"
+        )
+      )
 }

--- a/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffMicroBatchReader.scala
@@ -119,8 +119,8 @@ class AugmentedDiffMicroBatchReader(options: DataSourceOptions,
                                     checkpointLocation: String)
     extends ReplicationStreamMicroBatchReader(options, checkpointLocation) {
 
-  override def getCurrentOffset: SequenceOffset =
-    AugmentedDiffSource.createOffsetForCurrentSequence(baseURI)
+  override def getCurrentSequence: Int =
+    AugmentedDiffSource.getCurrentSequence(baseURI)
 
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
     sequenceRange

--- a/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffMicroBatchReader.scala
@@ -20,16 +20,16 @@ import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 case class AugmentedDiffStreamBatchTask(baseURI: URI,
-                                        start: SequenceOffset,
-                                        end: SequenceOffset)
+                                        start: Int,
+                                        end: Int)
     extends DataReaderFactory[Row] {
   override def createDataReader(): DataReader[Row] =
     new AugmentedDiffStreamBatchReader(baseURI, start, end)
 }
 
 class AugmentedDiffStreamBatchReader(baseURI: URI,
-                                     start: SequenceOffset,
-                                     end: SequenceOffset)
+                                     start: Int,
+                                     end: Int)
     extends ReplicationStreamBatchReader[
       (Option[AugmentedDiffFeature], AugmentedDiffFeature)
     ](baseURI, start, end) {
@@ -133,8 +133,10 @@ class AugmentedDiffMicroBatchReader(options: DataSourceOptions,
   override def readSchema(): StructType = AugmentedDiffSchema
 
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
-    List(
-      AugmentedDiffStreamBatchTask(baseURI, start.get, end.get)
-        .asInstanceOf[DataReaderFactory[Row]]
-    ).asJava
+    sequenceRange.map(
+        seq =>
+          AugmentedDiffStreamBatchTask(baseURI, seq, seq)
+            .asInstanceOf[DataReaderFactory[Row]]
+    )
+      .asJava
 }

--- a/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffSource.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/AugmentedDiffSource.scala
@@ -67,11 +67,6 @@ object AugmentedDiffSource extends Logging {
     }
   }
 
-  private[streaming] def createOffsetForCurrentSequence(
-    baseURI: URI
-  ): SequenceOffset =
-    SequenceOffset(getCurrentSequence(baseURI))
-
   @memoize(maxSize = 1, expiresAfter = 30 seconds)
   def getCurrentSequence(baseURI: URI): Int = {
     val bucket = baseURI.getHost

--- a/src/common/src/main/scala/osmesa/common/streaming/ChangesMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ChangesMicroBatchReader.scala
@@ -58,8 +58,8 @@ class ChangesMicroBatchReader(options: DataSourceOptions,
       .orElse("https://planet.osm.org/replication/minute/")
   )
 
-  override def getCurrentOffset: SequenceOffset =
-    ChangesSource.createOffsetForCurrentSequence(baseURI)
+  override def getCurrentSequence: Int =
+    ChangesSource.getCurrentSequence(baseURI)
 
   override def readSchema(): StructType = ChangeSchema
 

--- a/src/common/src/main/scala/osmesa/common/streaming/ChangesSource.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ChangesSource.scala
@@ -62,11 +62,6 @@ object ChangesSource extends Logging {
     }
   }
 
-  private[streaming] def createOffsetForCurrentSequence(
-    baseURI: URI
-  ): SequenceOffset =
-    SequenceOffset(getCurrentSequence(baseURI))
-
   @memoize(maxSize = 1, expiresAfter = 30 seconds)
   def getCurrentSequence(baseURI: URI): Int = {
     val response =

--- a/src/common/src/main/scala/osmesa/common/streaming/ChangesetsMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ChangesetsMicroBatchReader.scala
@@ -54,8 +54,8 @@ class ChangesetsMicroBatchReader(options: DataSourceOptions,
       .orElse("https://planet.osm.org/replication/changesets/")
   )
 
-  override def getCurrentOffset: SequenceOffset =
-    ChangesetsSource.createOffsetForCurrentSequence(baseURI)
+  override def getCurrentSequence: Int =
+    ChangesetsSource.getCurrentSequence(baseURI)
 
   override def readSchema(): StructType = ChangesetSchema
 

--- a/src/common/src/main/scala/osmesa/common/streaming/ChangesetsMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ChangesetsMicroBatchReader.scala
@@ -11,18 +11,15 @@ import osmesa.common.model.{Changeset, ChangesetSchema}
 
 import scala.collection.JavaConverters._
 
-case class ChangesetsStreamBatchTask(baseURI: URI,
-                                     start: Int,
-                                     end: Int)
+case class ChangesetsStreamBatchTask(baseURI: URI, sequence: Int)
     extends DataReaderFactory[Row] {
   override def createDataReader(): DataReader[Row] =
-    new ChangesetsStreamBatchReader(baseURI, start, end)
+    new ChangesetsStreamBatchReader(baseURI, sequence)
 }
 
-class ChangesetsStreamBatchReader(baseURI: URI,
-                                  start: Int,
-                                  end: Int)
-    extends ReplicationStreamBatchReader[Changeset](baseURI, start, end) {
+class ChangesetsStreamBatchReader(baseURI: URI, sequence: Int)
+    extends ReplicationStreamBatchReader[Changeset](baseURI, sequence) {
+
   override def getSequence(baseURI: URI, sequence: Int): Seq[Changeset] =
     ChangesetsSource.getSequence(baseURI, sequence)
 
@@ -30,7 +27,7 @@ class ChangesetsStreamBatchReader(baseURI: URI,
     val changeset = items(index)
 
     Row(
-      currentSequence,
+      sequence,
       changeset.id,
       changeset.createdAt,
       changeset.closedAt.orNull,
@@ -63,10 +60,10 @@ class ChangesetsMicroBatchReader(options: DataSourceOptions,
   override def readSchema(): StructType = ChangesetSchema
 
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
-    sequenceRange.map(
-      seq =>
-        ChangesetsStreamBatchTask(baseURI, seq, seq)
+    sequenceRange
+      .map(
+        ChangesetsStreamBatchTask(baseURI, _)
           .asInstanceOf[DataReaderFactory[Row]]
-    )
+      )
       .asJava
 }

--- a/src/common/src/main/scala/osmesa/common/streaming/ChangesetsSource.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ChangesetsSource.scala
@@ -62,11 +62,6 @@ object ChangesetsSource extends Logging {
     }
   }
 
-  private[streaming] def createOffsetForCurrentSequence(
-    baseURI: URI
-  ): SequenceOffset =
-    SequenceOffset(getCurrentSequence(baseURI))
-
   @memoize(maxSize = 1, expiresAfter = 30 seconds)
   def getCurrentSequence(baseURI: URI): Int = {
     val response =

--- a/src/common/src/main/scala/osmesa/common/streaming/ReplicationStreamMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ReplicationStreamMicroBatchReader.scala
@@ -3,6 +3,7 @@ package osmesa.common.streaming
 import java.net.URI
 import java.util.Optional
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
@@ -40,14 +41,12 @@ abstract class ReplicationStreamMicroBatchReader(options: DataSourceOptions,
                                                  checkpointLocation: String)
     extends MicroBatchReader
     with Logging {
-  val DefaultBatchSize: Int = 100
-
+  val DefaultBatchSize: Int = SparkEnv.get.conf.getInt("spark.sql.shuffle.partitions", 200)
   protected val batchSize: Int = options
     .get("batch_size")
     .asScala
     .map(s => s.toInt)
     .getOrElse(DefaultBatchSize)
-
   protected var startSequence: Option[Int] =
     options.get("start_sequence").asScala.map(_.toInt)
   protected var endSequence: Option[Int] =

--- a/src/common/src/main/scala/osmesa/common/streaming/ReplicationStreamMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ReplicationStreamMicroBatchReader.scala
@@ -15,11 +15,9 @@ import org.apache.spark.sql.sources.v2.reader.streaming.{
 import scala.compat.java8.OptionConverters._
 
 abstract class ReplicationStreamBatchReader[T](baseURI: URI,
-                                               start: Int,
-                                               end: Int)
+                                               sequence: Int)
     extends DataReader[Row]
     with Logging {
-  protected var currentSequence: Int = start
   protected var index: Int = -1
   protected var items: Vector[T] = _
 
@@ -28,20 +26,10 @@ abstract class ReplicationStreamBatchReader[T](baseURI: URI,
 
     if (Option(items).isEmpty) {
       // initialize items from the starting sequence
-      items = getSequence(baseURI, currentSequence).toVector
+      items = getSequence(baseURI, sequence).toVector
     }
 
-    // fetch next batch of items if necessary
-    // this is a loop in case sequences contain no items
-    while (index >= items.length && currentSequence < end) {
-      // fetch next sequence
-      currentSequence += 1
-      items = getSequence(baseURI, currentSequence).toVector
-
-      index = 0
-    }
-
-    currentSequence <= end && index < items.length
+    index < items.length
   }
 
   override def close(): Unit = Unit

--- a/src/common/src/main/scala/osmesa/common/streaming/ReplicationStreamMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/streaming/ReplicationStreamMicroBatchReader.scala
@@ -61,14 +61,14 @@ abstract class ReplicationStreamMicroBatchReader(options: DataSourceOptions,
 
   override def setOffsetRange(start: Optional[Offset],
                               end: Optional[Offset]): Unit = {
-    val currentOffset = getCurrentOffset
+    val currentSequence = getCurrentSequence
 
     startOffset = Some(
       start.asScala
         .map(_.asInstanceOf[SequenceOffset])
         .getOrElse {
           startOffset.getOrElse {
-            currentOffset - 1
+            SequenceOffset(currentSequence - 1)
           }
         }
     )
@@ -82,7 +82,7 @@ abstract class ReplicationStreamMicroBatchReader(options: DataSourceOptions,
           // jump straight to the end, batching if necessary
           endSequence.map(s => SequenceOffset(math.min(s, nextBatch))).getOrElse {
             // jump to the current sequence, batching if necessary
-            SequenceOffset(math.min(currentOffset.sequence, nextBatch))
+            SequenceOffset(math.min(currentSequence, nextBatch))
           }
         }
     )
@@ -106,7 +106,7 @@ abstract class ReplicationStreamMicroBatchReader(options: DataSourceOptions,
 
   override def stop(): Unit = Unit
 
-  protected def getCurrentOffset: SequenceOffset
+  protected def getCurrentSequence: Int
 
   // return an inclusive range
   protected def sequenceRange: Range =


### PR DESCRIPTION
Fixes various off-by-one errors resulting from varying `(.., ..]` (exclusive/inclusive) `[.., ..]` (inclusive/inclusive) ranges. Also handles sequence ranges provided as options correctly.

Fixes #75 