### PR TITLE
User footprint rendering improvements

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
@@ -7,7 +7,7 @@ import java.util.zip.GZIPInputStream
 
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.resample.Sum
-import geotrellis.raster.{IntArrayTile, RasterExtent, Raster => GTRaster, _}
+import geotrellis.raster.{RasterExtent, Raster => GTRaster, _}
 import geotrellis.spark.io.index.zcurve.ZSpatialKeyIndex
 import geotrellis.spark.tiling.ZoomedLayoutScheme
 import geotrellis.spark.{KeyBounds, SpatialKey}
@@ -23,6 +23,7 @@ import osmesa.analytics.updater.Implicits._
 import osmesa.analytics.updater.{makeLayer, path, read, write}
 import osmesa.common.model._
 import osmesa.common.model.impl._
+import osmesa.common.raster.MutableSparseIntTile
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.parallel.{ForkJoinTaskSupport, TaskSupport}
@@ -633,7 +634,7 @@ object Footprints extends Logging {
             case ((k, z, x, y), tiles) =>
               val sk = SpatialKey(x, y)
               val tileExtent = sk.extent(LayoutScheme.levelForZoom(z).layout)
-              val tile = IntArrayTile.ofDim(cols, rows, IntCellType)
+              val tile = MutableSparseIntTile(cols, rows)
               val rasterExtent = RasterExtent(tileExtent, tile.cols, tile.rows)
               val geoms = tiles.map(_.wkb.readWKB)
 
@@ -658,7 +659,7 @@ object Footprints extends Logging {
             case ((sequence, k, z, x, y), tiles) =>
               val sk = SpatialKey(x, y)
               val tileExtent = sk.extent(LayoutScheme.levelForZoom(z).layout)
-              val tile = IntArrayTile.ofDim(cols, rows, IntCellType)
+              val tile = MutableSparseIntTile(cols, rows)
               val rasterExtent = RasterExtent(tileExtent, tile.cols, tile.rows)
               val geoms = tiles.map(_.wkb.readWKB)
 

--- a/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
@@ -293,7 +293,7 @@ object Footprints extends Logging {
           val targetExtent =
             SpatialKey(tile.x, tile.y).extent(LayoutScheme.levelForZoom(tile.zoom).layout)
 
-          val newTile = rasters.head.tile.prototype(Cols, Rows)
+          val newTile = MutableSparseIntTile(Cols, Rows)
 
           rasters.foreach { raster => newTile.merge(targetExtent, raster.extent, raster.tile, Sum)
           }
@@ -639,7 +639,11 @@ object Footprints extends Logging {
               val geoms = tiles.map(_.wkb.readWKB)
 
               geoms.foreach(g =>
-                g.foreach(rasterExtent) { (c, r) => tile.set(c, r, tile.get(c, r) + 1)
+                g.foreach(rasterExtent) { (c, r) =>
+                  tile.get(c, r) match {
+                    case v if isData(v) => tile.set(c, r, v + 1)
+                    case _              => tile.set(c, r, 1)
+                  }
               })
 
               RasterTileWithKey(k, z, x, y, GTRaster.tupToRaster(tile, tileExtent))
@@ -664,7 +668,11 @@ object Footprints extends Logging {
               val geoms = tiles.map(_.wkb.readWKB)
 
               geoms.foreach(g =>
-                g.foreach(rasterExtent) { (c, r) => tile.set(c, r, tile.get(c, r) + 1)
+                g.foreach(rasterExtent) { (c, r) =>
+                  tile.get(c, r) match {
+                    case v if isData(v) => tile.set(c, r, v + 1)
+                    case _              => tile.set(c, r, 1)
+                  }
               })
 
               RasterTileWithKeyAndSequence(sequence,

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
@@ -132,13 +132,15 @@ object Footprint extends Logging {
       case _ => throw new RuntimeException("Unrecognized footprint type")
     }
 
+    // TODO make changesets optional
+    // TODO accept a list of users
+
     val nodes = history
       .where('type === "node" and 'lat.isNotNull and 'lon.isNotNull)
       .select('lat, 'lon, 'key)
-      .repartition('key)
 
     val stats = Footprints.createFootprints(nodes, outputURI)
-    stats.write.mode(SaveMode.Overwrite).csv("/tmp/footprints/")
+    stats.repartition(1).write.mode(SaveMode.Overwrite).csv("/tmp/footprints/")
 
     spark.stop()
   }

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
@@ -72,8 +72,8 @@ object Footprint extends Logging {
             .orc(historyURI.toString)
             // TODO this is dataset-specific
             .where(!('uid isin (0, 1)))
-            // use the username as the footprint key
-            .withColumnRenamed("user", "key")
+            // use the user id as the footprint key
+            .withColumnRenamed("uid", "key")
         } else {
           logInfo(s"Finding users who've participated in ${targetHashtags.mkString(", ")}")
 
@@ -91,8 +91,8 @@ object Footprint extends Logging {
           spark.read
             .orc(historyURI.toString)
             .join(targetUsers, Seq("uid"))
-            // use the username as the footprint key
-            .withColumnRenamed("user", "key")
+            // use the user id as the footprint key
+            .withColumnRenamed("uid", "key")
         }
       case "hashtags" =>
         if (targetHashtags.isEmpty) {

--- a/src/common/src/main/scala/osmesa/common/model/impl/package.scala
+++ b/src/common/src/main/scala/osmesa/common/model/impl/package.scala
@@ -1,6 +1,6 @@
 package osmesa.common.model
 
-import geotrellis.raster.{ArrayTile, CellType, IntArrayTile, MutableArrayTile, Tile, isData, Raster => GTRaster}
+import geotrellis.raster.{IntArrayTile, Tile, isData, Raster => GTRaster}
 import geotrellis.vector.Extent
 import osmesa.common.raster.{MutableSparseIntTile, SparseIntTile}
 
@@ -46,10 +46,9 @@ package object impl {
                                zoom: Int,
                                x: Int,
                                y: Int,
-                               tileValues: Map[Long, Int],
-                               tileCols: Int,
-                               tileRows: Int,
-                               tileCellType: String,
+                               values: Map[Long, Int],
+                               cols: Int,
+                               rows: Int,
                                xmin: Double,
                                ymin: Double,
                                xmax: Double,
@@ -57,14 +56,9 @@ package object impl {
       extends RasterTile
       with Key {
     lazy val raster: GTRaster[Tile] = GTRaster.tupToRaster(
-      SparseIntTile(tileCols, tileRows, tileValues),
+      SparseIntTile(cols, rows, values),
       Extent(xmin, ymin, xmax, ymax)
     )
-
-    override def prototype(cols: Int, rows: Int): MutableArrayTile =
-      ArrayTile.empty(cellType, tileCols, tileRows)
-
-    def cellType: CellType = CellType.fromName(tileCellType)
   }
 
   case class RasterTileWithKeyAndSequence(sequence: Int,
@@ -72,10 +66,9 @@ package object impl {
                                           zoom: Int,
                                           x: Int,
                                           y: Int,
-                                          tileValues: Map[Long, Int],
-                                          tileCols: Int,
-                                          tileRows: Int,
-                                          tileCellType: String,
+                                          values: Map[Long, Int],
+                                          cols: Int,
+                                          rows: Int,
                                           xmin: Double,
                                           ymin: Double,
                                           xmax: Double,
@@ -84,14 +77,9 @@ package object impl {
       with Key
       with Sequence {
     lazy val raster: GTRaster[Tile] = GTRaster.tupToRaster(
-      SparseIntTile(tileCols, tileRows, tileValues),
+      SparseIntTile(cols, rows, values),
       Extent(xmin, ymin, xmax, ymax)
     )
-
-    override def prototype(cols: Int, rows: Int): MutableArrayTile =
-      ArrayTile.empty(cellType, tileCols, tileRows)
-
-    def cellType: CellType = CellType.fromName(tileCellType)
   }
 
   case class RasterWithSequenceTileSeqWithTileCoordinatesAndKey(tiles: Seq[RasterWithSequence],
@@ -103,10 +91,9 @@ package object impl {
       with TileCoordinates
       with Key
 
-  case class RasterWithSequence(tileValues: Map[Long, Int],
-                                tileCols: Int,
-                                tileRows: Int,
-                                tileCellType: String,
+  case class RasterWithSequence(values: Map[Long, Int],
+                                cols: Int,
+                                rows: Int,
                                 xmin: Double,
                                 ymin: Double,
                                 xmax: Double,
@@ -115,14 +102,9 @@ package object impl {
       extends Raster
       with Sequence {
     lazy val raster: GTRaster[Tile] = GTRaster.tupToRaster(
-      SparseIntTile(tileCols, tileRows, tileValues),
+      SparseIntTile(cols, rows, values),
       Extent(xmin, ymin, xmax, ymax)
     )
-
-    override def prototype(cols: Int, rows: Int): MutableArrayTile =
-      ArrayTile.empty(cellType, tileCols, tileRows)
-
-    def cellType: CellType = CellType.fromName(tileCellType)
   }
 
   case class CountWithTileCoordinatesAndKey(count: Long, zoom: Int, x: Int, y: Int, key: String)
@@ -174,7 +156,6 @@ package object impl {
         raster.toMap,
         raster.cols,
         raster.rows,
-        raster.cellType.name,
         raster.extent.xmin,
         raster.extent.ymin,
         raster.extent.xmax,
@@ -198,7 +179,6 @@ package object impl {
         raster.toMap,
         raster.cols,
         raster.rows,
-        raster.cellType.name,
         raster.extent.xmin,
         raster.extent.ymin,
         raster.extent.xmax,
@@ -214,7 +194,6 @@ package object impl {
         raster.toMap,
         raster.cols,
         raster.rows,
-        raster.cellType.name,
         raster.extent.xmin,
         raster.extent.ymin,
         raster.extent.xmax,

--- a/src/common/src/main/scala/osmesa/common/model/package.scala
+++ b/src/common/src/main/scala/osmesa/common/model/package.scala
@@ -149,6 +149,7 @@ package object model {
   trait GeometryTile extends SerializedGeometry with TileCoordinates
 
   trait Raster {
+    def prototype(cols: Int, rows: Int): MutableArrayTile
     def raster: GTRaster[Tile]
   }
 

--- a/src/common/src/main/scala/osmesa/common/model/package.scala
+++ b/src/common/src/main/scala/osmesa/common/model/package.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.time.Instant
 
 import cats.syntax.either._
-import geotrellis.raster.{Tile, Raster => GTRaster}
+import geotrellis.raster.{MutableArrayTile, Tile, Raster => GTRaster}
 import geotrellis.vector.io._
 import geotrellis.vector.{Feature, Point, Geometry => GTGeometry}
 import io.circe._

--- a/src/common/src/main/scala/osmesa/common/model/package.scala
+++ b/src/common/src/main/scala/osmesa/common/model/package.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.time.Instant
 
 import cats.syntax.either._
-import geotrellis.raster.{MutableArrayTile, Tile, Raster => GTRaster}
+import geotrellis.raster.{Tile, Raster => GTRaster}
 import geotrellis.vector.io._
 import geotrellis.vector.{Feature, Point, Geometry => GTGeometry}
 import io.circe._
@@ -149,7 +149,6 @@ package object model {
   trait GeometryTile extends SerializedGeometry with TileCoordinates
 
   trait Raster {
-    def prototype(cols: Int, rows: Int): MutableArrayTile
     def raster: GTRaster[Tile]
   }
 

--- a/src/common/src/main/scala/osmesa/common/raster/package.scala
+++ b/src/common/src/main/scala/osmesa/common/raster/package.scala
@@ -44,6 +44,8 @@ package object raster {
 
     override def copy: ArrayTile = SparseIntTile(cols, rows, Map(values.toSeq: _*), cellType)
 
+    // unimplemented because it doesn't make sense in this context (and SparseIntTile can't be instantiated from
+    // Array[Byte])
     override def toBytes(): Array[Byte] = ???
 
     def toMap: Map[Long, Int] = values
@@ -96,6 +98,8 @@ package object raster {
 
     override def copy: ArrayTile = MutableSparseIntTile(cols, rows, values.clone(), cellType)
 
+    // unimplemented because it doesn't make sense in this context (and MutableSparseIntTile can't be instantiated from
+    // Array[Byte])
     override def toBytes(): Array[Byte] = ???
 
     def toMap: Map[Long, Int] = values.toMap

--- a/src/common/src/main/scala/osmesa/common/raster/package.scala
+++ b/src/common/src/main/scala/osmesa/common/raster/package.scala
@@ -1,0 +1,129 @@
+package osmesa.common
+import geotrellis.macros.IntTileVisitor
+import geotrellis.raster.{
+  ArrayTile,
+  CellType,
+  IntCellType,
+  IntCells,
+  IntConstantNoDataCellType,
+  IntUserDefinedNoDataCellType,
+  MutableArrayTile,
+  NoDataHandling,
+  Tile
+}
+
+import scala.collection.mutable
+
+package object raster {
+  class SparseIntTile(val cols: Int,
+                      val rows: Int,
+                      val values: Map[Long, Int],
+                      val cellType: IntCells with NoDataHandling)
+      extends ArrayTile {
+    private val noDataValue = cellType match {
+      case IntConstantNoDataCellType        => Int.MinValue
+      case IntUserDefinedNoDataCellType(nd) => nd
+      case IntCellType                      => 0
+    }
+
+    def interpretAs(newCellType: CellType): Tile = {
+      newCellType match {
+        case dt: IntCells with NoDataHandling =>
+          SparseIntTile(cols, rows, values, dt)
+        case _ =>
+          withNoData(None).convert(newCellType)
+      }
+    }
+
+    def withNoData(noDataValue: Option[Double]): Tile =
+      SparseIntTile(cols, rows, values, cellType.withNoData(noDataValue))
+
+    override def applyDouble(i: Int): Double = apply(i).toDouble
+
+    override def apply(i: Int): Int = values.getOrElse(i, 0)
+
+    override def copy: ArrayTile = SparseIntTile(cols, rows, Map(values.toSeq: _*), cellType)
+
+    override def toBytes(): Array[Byte] = ???
+
+    def toMap: Map[Long, Int] = values
+
+    override def mutable: MutableArrayTile =
+      MutableSparseIntTile(cols, rows, scala.collection.mutable.LongMap(values.toSeq: _*), cellType)
+
+    override def foreachIntVisitor(visitor: IntTileVisitor): Unit = {
+      // NOTE only visits coordinates containing data; this isn't strictly correct for some uses
+      values.foreach {
+        case (k, v) =>
+          val col = k % cols
+          val row = k / cols
+
+          visitor(col.toInt, row.toInt, v)
+      }
+    }
+  }
+
+  class MutableSparseIntTile(val cols: Int,
+                             val rows: Int,
+                             val values: scala.collection.mutable.LongMap[Int],
+                             val cellType: IntCells with NoDataHandling)
+      extends MutableArrayTile {
+    private val noDataValue = cellType match {
+      case IntConstantNoDataCellType        => Int.MinValue
+      case IntUserDefinedNoDataCellType(nd) => nd
+      case IntCellType                      => 0
+    }
+
+    override def updateDouble(i: Int, z: Double): Unit = update(i, z.toInt)
+
+    override def update(i: Int, z: Int): Unit = values(i) = z
+
+    def interpretAs(newCellType: CellType): Tile = {
+      newCellType match {
+        case dt: IntCells with NoDataHandling =>
+          MutableSparseIntTile(cols, rows, values, dt)
+        case _ =>
+          withNoData(None).convert(newCellType)
+      }
+    }
+
+    def withNoData(noDataValue: Option[Double]): Tile =
+      MutableSparseIntTile(cols, rows, values, cellType.withNoData(noDataValue))
+
+    override def applyDouble(i: Int): Double = apply(i).toDouble
+
+    override def apply(i: Int): Int = values.getOrElse(i, 0)
+
+    override def copy: ArrayTile = MutableSparseIntTile(cols, rows, values.clone(), cellType)
+
+    override def toBytes(): Array[Byte] = ???
+
+    def toMap: Map[Long, Int] = values.toMap
+
+    override def foreachIntVisitor(visitor: IntTileVisitor): Unit = {
+      values.foreach {
+        case (k, v) =>
+          val col = k % cols
+          val row = k / cols
+
+          visitor(col.toInt, row.toInt, v)
+      }
+    }
+  }
+
+  object SparseIntTile {
+    def apply(cols: Int,
+              rows: Int,
+              values: Map[Long, Int] = Map.empty[Long, Int],
+              cellType: IntCells with NoDataHandling = IntConstantNoDataCellType) =
+      new SparseIntTile(cols, rows, values, cellType)
+  }
+
+  object MutableSparseIntTile {
+    def apply(cols: Int,
+              rows: Int,
+              values: mutable.LongMap[Int] = mutable.LongMap.empty[Int],
+              cellType: IntCells with NoDataHandling = IntConstantNoDataCellType) =
+      new MutableSparseIntTile(cols, rows, values, cellType)
+  }
+}

--- a/src/common/src/main/scala/osmesa/common/raster/package.scala
+++ b/src/common/src/main/scala/osmesa/common/raster/package.scala
@@ -9,7 +9,8 @@ import geotrellis.raster.{
   IntUserDefinedNoDataCellType,
   MutableArrayTile,
   NoDataHandling,
-  Tile
+  Tile,
+  isData
 }
 
 import scala.collection.mutable
@@ -40,7 +41,7 @@ package object raster {
 
     override def applyDouble(i: Int): Double = apply(i).toDouble
 
-    override def apply(i: Int): Int = values.getOrElse(i, 0)
+    override def apply(i: Int): Int = values.getOrElse(i, noDataValue)
 
     override def copy: ArrayTile = SparseIntTile(cols, rows, Map(values.toSeq: _*), cellType)
 
@@ -78,7 +79,13 @@ package object raster {
 
     override def updateDouble(i: Int, z: Double): Unit = update(i, z.toInt)
 
-    override def update(i: Int, z: Int): Unit = values(i) = z
+    override def update(i: Int, z: Int): Unit = {
+      if (isData(z)) {
+        values(i) = z
+      } else {
+        values.remove(i)
+      }
+    }
 
     def interpretAs(newCellType: CellType): Tile = {
       newCellType match {
@@ -94,7 +101,7 @@ package object raster {
 
     override def applyDouble(i: Int): Double = apply(i).toDouble
 
-    override def apply(i: Int): Int = values.getOrElse(i, 0)
+    override def apply(i: Int): Int = values.getOrElse(i, noDataValue)
 
     override def copy: ArrayTile = MutableSparseIntTile(cols, rows, values.clone(), cellType)
 


### PR DESCRIPTION
Namely, that it actually runs through.

When generating footprints for large numbers of users, many, many intermediate tiles are produced. Prior to SparseIntTile, each was backed by an array of rows * cols but was largely empty. Spark shuffle / spill serialization compressed the Array[Byte] representations of these backing arrays **extremely** well. However, Spark reliably OOM'd while deserializing and allocating these large backing arrays.

By switching to `Map`- and `LongMap`-backed `IntTile`s, memory usage is **dramatically** reduced (the Detroit sample went from a 2.7GB in-memory representation to 39MB) *for this use-case* (where tiles are largely empty) with the additional benefit of being able to pass the backing `Map`s directly to Spark without an intermediate deserialization step.