### PR TITLE
Omitting host in a database URL defaults to localhost

### DIFF
--- a/src/common/src/main/scala/osmesa/common/util/DBUtils.scala
+++ b/src/common/src/main/scala/osmesa/common/util/DBUtils.scala
@@ -8,7 +8,7 @@ object DBUtils {
 
     val cleanUri = new URI(
       uri.getScheme,
-      uri.getHost + (if (uri.getPort > 0) ":" + uri.getPort  else ""),
+      Option(uri.getHost).getOrElse("localhost") + (if (uri.getPort > 0) ":" + uri.getPort  else ""),
       uri.getPath,
       null.asInstanceOf[String],
       null.asInstanceOf[String]


### PR DESCRIPTION
Previously, it defaulted to `null`, which prevented URLs like `postgresql:///db` from working.