### PR TITLE
Misc fixes

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
@@ -7,11 +7,11 @@ import com.monovore.decline.{CommandApp, Opts}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.locationtech.geomesa.spark.jts.st_length
 import osmesa.analytics.Analytics
 import osmesa.common.ProcessOSM
 import osmesa.common.functions._
 import osmesa.common.functions.osm._
-
 
 object ChangesetStats extends CommandApp(
   name = "changeset-stats",
@@ -44,8 +44,7 @@ object ChangesetStats extends CommandApp(
 
       @transient val idByUpdated = Window.partitionBy('id).orderBy('updated)
 
-      val augmentedWays = wayGeoms
-        .withColumn("length", ST_Length('geom))
+      val augmentedWays = wayGeoms.withColumn("length", st_length('geom))
         .withColumn("delta",
           when(isRoad('tags) or isWaterway('tags),
             coalesce(abs('length - (lag('length, 1) over idByUpdated)), lit(0)))

--- a/src/analytics/src/main/scala/osmesa/analytics/updater/Implicits.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/updater/Implicits.scala
@@ -3,12 +3,12 @@ package osmesa.analytics.updater
 import geotrellis.vectortile.{VInt64, VString, Value}
 
 object Implicits {
-  implicit def valueToLong(x: Value): Long = x match {
+  implicit def valueToLong(x: Value): Long = (x: @unchecked) match {
     case y: VInt64  => y.value
     case y: VString => y.value.toLong
   }
 
-  implicit def valueToString(x: Value): String = x match {
+  implicit def valueToString(x: Value): String = (x: @unchecked) match {
     case y: VInt64  => y.value.toString
     case y: VString => y.value
   }

--- a/src/common/build.sbt
+++ b/src/common/build.sbt
@@ -42,3 +42,11 @@ Test / testOptions += Tests.Argument("-oDF")
 initialCommands in console :=
   """
   """
+
+assemblyMergeStrategy in assembly := {
+  case s if s.startsWith("META-INF/services") => MergeStrategy.concat
+  case "reference.conf" | "application.conf"  => MergeStrategy.concat
+  case "META-INF/MANIFEST.MF" | "META-INF\\MANIFEST.MF" => MergeStrategy.discard
+  case "META-INF/ECLIPSE_.RSA" | "META-INF/ECLIPSE_.SF" => MergeStrategy.discard
+  case _ => MergeStrategy.first
+}

--- a/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
+++ b/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
@@ -23,6 +23,10 @@ import org.apache.spark.sql.jts.GeometryUDT
 import com.vividsolutions.jts.{geom => jts}
 
 object ProcessOSM {
+  private val ss: SparkSession = SparkSession.builder.getOrCreate()
+  // initialize JTS support
+  ss.withJTS
+
   val NodeType: Byte = 1
   val WayType: Byte = 2
   val RelationType: Byte = 3

--- a/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
+++ b/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
@@ -730,7 +730,7 @@ object ProcessOSM {
         val countryLookup = new CountryLookup()
 
         partition.map { row =>
-          val countryCodes = Option(row.getAs[Array[Byte]]("geom")).map(_.readWKB) match {
+          val countryCodes = Option(row.getAs[jts.Geometry]("geom")).map(Geometry(_)) match {
             case Some(geom) => countryLookup.lookup(geom).map(x => x.code)
             case None => Seq.empty[String]
           }

--- a/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
+++ b/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
@@ -121,8 +121,8 @@ object ProcessOSM {
           when(!'visible and (lag('tags, 1) over idByVersion).isNotNull,
             lag('tags, 1) over idByVersion)
             .otherwise('tags) as 'tags,
-          when(!'visible, lit(Float.NaN)).otherwise(asFloat('lat)) as 'lat,
-          when(!'visible, lit(Float.NaN)).otherwise(asFloat('lon)) as 'lon,
+          when(!'visible, lit(Double.NaN)).otherwise(asDouble('lat)) as 'lat,
+          when(!'visible, lit(Double.NaN)).otherwise(asDouble('lon)) as 'lon,
           'changeset,
           'timestamp,
           (lead('timestamp, 1) over idByVersion) as 'validUntil,
@@ -344,8 +344,8 @@ object ProcessOSM {
           val geom = nds
             .sortWith((a, b) => a.getAs[Int]("idx") < b.getAs[Int]("idx"))
             .map { row =>
-              Seq(Option(row.get(row.fieldIndex("lon"))).map(_.asInstanceOf[Float]).getOrElse(Float.NaN),
-                  Option(row.get(row.fieldIndex("lat"))).map(_.asInstanceOf[Float]).getOrElse(Float.NaN))
+              Seq(Option(row.get(row.fieldIndex("lon"))).map(_.asInstanceOf[Double]).getOrElse(Double.NaN),
+                  Option(row.get(row.fieldIndex("lat"))).map(_.asInstanceOf[Double]).getOrElse(Double.NaN))
             } match {
               // no coordinates provided
               case coords if coords.isEmpty => Some(GeomFactory.factory.createLineString(Array.empty[jts.Coordinate]))

--- a/src/ingest/src/main/scala/osmesa/ingest/TagChanges.scala
+++ b/src/ingest/src/main/scala/osmesa/ingest/TagChanges.scala
@@ -1,0 +1,107 @@
+package osmesa.ingest
+
+import cats.implicits._
+import com.monovore.decline._
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark._
+import org.apache.spark.sql._
+import org.apache.spark.sql.expressions.{UserDefinedFunction, Window}
+import org.apache.spark.sql.functions._
+
+/*
+ * Usage example:
+ *
+ * sbt "project ingest" assembly
+ *
+ * spark-submit \
+ *   --class osmesa.ingest.TagChanges \
+ *   ingest/target/scala-2.11/osmesa-ingest.jar \
+ *   --orc=$HOME/data/osm/isle-of-man.orc \
+ *   --out=$HOME/data/osm/isle-of-man-geoms.orc \
+ */
+
+object TagChanges extends CommandApp(
+      name = "osmesa-tag-changes",
+      header = "Generate tag differences between element versions",
+      main = {
+
+        /* CLI option handling */
+        val orcOpt = Opts
+          .option[String]("orc", help = "Location of the ORC file to process")
+        val outOpt =
+          Opts.option[String]("out", help = "ORC file containing geometries")
+        val numPartitionsOpt = Opts
+          .option[Int]("partitions", help = "Number of partitions to generate")
+          .withDefault(1)
+
+        (orcOpt, outOpt, numPartitionsOpt).mapN {
+          (orc, out, numPartitions) =>
+            /* Settings compatible for both local and EMR execution */
+            val conf = new SparkConf()
+              .setIfMissing("spark.master", "local[*]")
+              .setAppName("make-geometries")
+              .set(
+                "spark.serializer",
+                classOf[org.apache.spark.serializer.KryoSerializer].getName
+              )
+              .set(
+                "spark.kryo.registrator",
+                classOf[geotrellis.spark.io.kryo.KryoRegistrator].getName
+              )
+              .set("spark.ui.showConsoleProgress", "true")
+
+            implicit val ss: SparkSession = SparkSession.builder
+              .config(conf)
+              .enableHiveSupport
+              .getOrCreate
+
+            import ss.implicits._
+
+            /* Silence the damn INFO logger */
+            Logger.getRootLogger.setLevel(Level.WARN)
+
+            val df = ss.read.orc(orc)
+
+            @transient val idByVersion =
+              Window.partitionBy('id).orderBy('version)
+
+            val _tagsAdded =
+              (prev: Map[String, String], curr: Map[String, String]) => {
+                if (prev == null) {
+                  curr
+                } else {
+                  (curr.toSet diff prev.toSet).toMap
+                }
+              }
+
+            val tagsAdded: UserDefinedFunction = udf(_tagsAdded)
+
+            val _tagsRemoved =
+              (prev: Map[String, String], curr: Map[String, String]) => {
+                if (prev == null) {
+                  Map.empty[String, String]
+                } else {
+                  (prev.toSet diff curr.toSet).toMap
+                }
+              }
+
+            val tagsRemoved: UserDefinedFunction = udf(_tagsRemoved)
+
+            df.withColumn("prevTags", lag('tags, 1) over idByVersion)
+              .withColumn("tagsAdded", tagsAdded('prevTags, 'tags))
+              .withColumn("tagsRemoved", tagsRemoved('prevTags, 'tags))
+              .drop('lat)
+              .drop('lon)
+              .drop('nds)
+              .drop('members)
+              .repartition(numPartitions)
+              .write
+              .mode(SaveMode.Overwrite)
+              .orc(out)
+
+            ss.stop()
+
+            println("Done.")
+        }
+      }
+    )


### PR DESCRIPTION
This fixes up some UDFs that weren't migrated to Spark JTS, changes lat/lon representation to `Double`s (to match OSM precision), silences a minor compiler warning, and fixes assembly construction (some dependency had its signature filename change from `ECLIPSEF.RSA` to `ECLIPSE_.RSA`). This also adds a new oneoff: `TagChanges`, which will produce tagging deltas between element versions.

The primary upshot of this is that `ChangesetStats` will run to completion again.