### PR TITLE
Add last_edit to user_statistics

### DIFF
--- a/deployment/sql/materialized_views/user_statistics.sql
+++ b/deployment/sql/materialized_views/user_statistics.sql
@@ -76,6 +76,7 @@ WITH country_counts AS (
            sum(chg.buildings_modified) AS buildings_modified,
            sum(chg.pois_added) AS pois_added,
            sum(chg.pois_modified) AS pois_modified,
+           max(coalesce(chg.closed_at, chg.created_at)) AS last_edit,
            count(*) AS changeset_count,
            count(*) AS edit_count,
            max(COALESCE(chg.closed_at, chg.created_at, chg.updated_at)) AS updated_at
@@ -100,6 +101,7 @@ WITH country_counts AS (
      agg_stats.buildings_modified,
      agg_stats.pois_added,
      agg_stats.pois_modified,
+     agg_stats.last_edit,
      agg_stats.changeset_count,
      agg_stats.edit_count,
      usr_editor_counts.editor_json AS editors,
@@ -112,4 +114,3 @@ WITH country_counts AS (
       LEFT JOIN usr_hashtag_counts ON ((agg_stats.id = usr_hashtag_counts.user_id)))
       LEFT JOIN usr_day_counts ON ((agg_stats.id = usr_day_counts.user_id)))
       LEFT JOIN usr_editor_counts ON ((agg_stats.id = usr_editor_counts.user_id)));
-


### PR DESCRIPTION
In order to more accurately track the most recent activity of a user, we must surface this information in the materialized views.  This contribution attempts to do this.

Closes #95 