### PR TITLE
`constructGeometries` should produce a geom column with type `Geometry`

### DIFF
--- a/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
+++ b/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
@@ -219,11 +219,13 @@ object ProcessOSM {
     */
   def constructGeometries(elements: DataFrame): DataFrame = {
     import elements.sparkSession.implicits._
+    val st_pointToGeom = org.apache.spark.sql.functions.udf { pt: jts.Point => pt.asInstanceOf[jts.Geometry] }
 
     val nodes = ProcessOSM.preprocessNodes(elements)
 
     val nodeGeoms = ProcessOSM.constructPointGeometries(nodes)
       .withColumn("minorVersion", lit(0))
+      .withColumn("geom", st_pointToGeom('geom))
 
     val wayGeoms = ProcessOSM.reconstructWayGeometries(elements, nodes)
 


### PR DESCRIPTION
Due to the order of joining in `ProcessOSM.constructGeometries`, the resulting frame has a `geom` column of type `point`.  Since JTS frames only provides functions to make geometries more specific and reversing the join order is not allowed (for some reason), I've provided a local udf to do the conversion.