### PR TITLE
Replace BigDecimals with Doubles

### DIFF
--- a/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
+++ b/src/common/src/main/scala/osmesa/common/ProcessOSM.scala
@@ -13,7 +13,6 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-import osmesa.common.functions._
 import osmesa.common.functions.osm._
 import osmesa.common.util.Caching
 import spray.json._
@@ -121,8 +120,8 @@ object ProcessOSM {
           when(!'visible and (lag('tags, 1) over idByVersion).isNotNull,
             lag('tags, 1) over idByVersion)
             .otherwise('tags) as 'tags,
-          when(!'visible, lit(Double.NaN)).otherwise(asDouble('lat)) as 'lat,
-          when(!'visible, lit(Double.NaN)).otherwise(asDouble('lon)) as 'lon,
+          when(!'visible, lit(Double.NaN)).otherwise('lat) as 'lat,
+          when(!'visible, lit(Double.NaN)).otherwise('lon) as 'lon,
           'changeset,
           'timestamp,
           (lead('timestamp, 1) over idByVersion) as 'validUntil,
@@ -256,7 +255,7 @@ object ProcessOSM {
       .select(
         lit(NodeType) as '_type,
         'id,
-        st_makePoint('lon, 'lat) as 'geom,
+        when('lon.isNotNull and 'lat.isNotNull, st_makePoint('lon, 'lat)) as 'geom,
         'tags,
         'changeset,
         'updated,

--- a/src/common/src/main/scala/osmesa/common/model/Element.scala
+++ b/src/common/src/main/scala/osmesa/common/model/Element.scala
@@ -1,6 +1,5 @@
 package osmesa.common.model
 
-import java.math.BigDecimal
 import java.sql.Timestamp
 
 import org.joda.time.DateTime
@@ -14,8 +13,8 @@ import scala.xml.Node
 case class Element(_type: Byte,
                    id: Long,
                    tags: Map[String, String],
-                   lat: Option[BigDecimal],
-                   lon: Option[BigDecimal],
+                   lat: Option[Double],
+                   lon: Option[Double],
                    nds: Option[Seq[Long]],
                    members: Option[Seq[Member]],
                    changeset: Long,
@@ -40,11 +39,11 @@ object Element {
       (node \ "tag").map(tag => (tag \@ "k", tag \@ "v")).toMap
     val lat = node \@ "lat" match {
       case "" => None
-      case v  => Some(new BigDecimal(v))
+      case v  => Some(v.toDouble)
     }
     val lon = node \@ "lon" match {
       case "" => None
-      case v  => Some(new BigDecimal(v))
+      case v  => Some(v.toDouble)
     }
     val nds = _type match {
       case WayType =>

--- a/src/common/src/main/scala/osmesa/common/model/impl/package.scala
+++ b/src/common/src/main/scala/osmesa/common/model/impl/package.scala
@@ -5,7 +5,7 @@ import geotrellis.vector.Extent
 import osmesa.common.raster.{MutableSparseIntTile, SparseIntTile}
 
 package object impl {
-  case class CoordinatesWithKey(key: String, lat: Option[BigDecimal], lon: Option[BigDecimal])
+  case class CoordinatesWithKey(key: String, lat: Option[Double], lon: Option[Double])
       extends Coordinates
       with Key
 
@@ -13,8 +13,8 @@ package object impl {
 
   case class CoordinatesWithKeyAndSequence(sequence: Int,
                                            key: String,
-                                           lat: Option[BigDecimal],
-                                           lon: Option[BigDecimal])
+                                           lat: Option[Double],
+                                           lon: Option[Double])
       extends Coordinates
       with Key
       with Sequence

--- a/src/common/src/main/scala/osmesa/common/model/package.scala
+++ b/src/common/src/main/scala/osmesa/common/model/package.scala
@@ -126,8 +126,8 @@ package object model {
   trait RasterTile extends Raster with TileCoordinates
 
   trait Coordinates extends Geometry {
-    def lat: Option[BigDecimal]
-    def lon: Option[BigDecimal]
+    def lat: Option[Double]
+    def lon: Option[Double]
 
     def geom: Point = Point(x, y)
 


### PR DESCRIPTION
`Double`s are equivalent for our purposes and work better with `ExpressionEncoder`s (`BigDecimal`s were being converted to `null` when serialized into `Row`s as part of #106). Spark JTS geometry constructions are happy with either, so this shouldn't affect anything.