### PR TITLE
User footprint fixes

### DIFF
--- a/src/analytics/build.sbt
+++ b/src/analytics/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "42.2.2",
 
   decline,
-  sparkHive % "provided",
+  sparkHive % Provided,
   gtGeotools exclude("com.google.protobuf", "protobuf-java"),
   gtS3 exclude("com.google.protobuf", "protobuf-java") exclude("com.amazonaws", "aws-java-sdk-s3"),
   gtSpark exclude("com.google.protobuf", "protobuf-java"),
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   logging,
   scalatest,
 
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.340" % "provided"
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.340" % Provided
 )
 
 /* Fixes Spark breakage with `sbt run` as of sbt-1.0.2 */

--- a/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
@@ -264,10 +264,8 @@ object Footprints extends Logging {
           val targetExtent =
             SpatialKey(tile.x, tile.y).extent(LayoutScheme.levelForZoom(tile.zoom).layout)
 
-          val newTile = MutableSparseIntTile(Cols, Rows)
-
-          rasters.foreach { raster => newTile.merge(targetExtent, raster.extent, raster.tile, Sum)
-          }
+          val newTile = rasters.foldLeft(MutableSparseIntTile(Cols, Rows): Tile)((acc, raster) =>
+            acc.merge(targetExtent, raster.extent, raster.tile, Sum))
 
           (tile.key,
            tile.zoom,

--- a/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
@@ -292,7 +292,7 @@ object Footprints extends Logging {
           RasterWithSequenceTileSeqWithTileCoordinatesAndKey(
             tiles
               .map(x => RasterWithSequence(x.raster, x.sequence))
-              .toSeq,
+              .toVector, // this CANNOT be toSeq, as that produces a stream, which is subsequently partially consumed
             z,
             x,
             y,

--- a/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/Footprints.scala
@@ -241,10 +241,10 @@ object Footprints extends Logging {
       .map(tile => {
         val sk = SpatialKey(tile.x, tile.y)
         val uri = makeURI(tileSource, tile.key, tile.zoom, sk)
+        val committedSequences = mvts.get(uri).map(getCommittedSequences).getOrElse(Set.empty[Int])
 
         RasterWithSequenceTileSeqWithTileCoordinatesAndKey(
-          tile.tiles.filter(t =>
-            !mvts.get(uri).map(getCommittedSequences).exists(_.contains(t.sequence))),
+          tile.tiles.filterNot(t => committedSequences.contains(t.sequence)),
           tile.zoom,
           tile.x,
           tile.y,

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
@@ -8,6 +8,7 @@ import com.monovore.decline._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.DoubleType
 import osmesa.analytics.{Analytics, Footprints, S3Utils}
 import osmesa.common.functions.osm._
 
@@ -137,7 +138,7 @@ object Footprint extends Logging {
 
     val nodes = history
       .where('type === "node" and 'lat.isNotNull and 'lon.isNotNull)
-      .select('lat, 'lon, 'key)
+      .select('lat.cast(DoubleType) as 'lat, 'lon.cast(DoubleType) as 'lon, 'key)
 
     val stats = Footprints.createFootprints(nodes, outputURI)
     stats.repartition(1).write.mode(SaveMode.Overwrite).csv("/tmp/footprints/")

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/HashtagFootprintUpdater.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/HashtagFootprintUpdater.scala
@@ -187,9 +187,8 @@ object HashtagFootprintUpdater
               .join(changedNodes, Seq("changeset"))
 
             val tiledNodes =
-              Footprints.updateFootprints(tileSource,
-                                          changedNodesWithHashtags
-                                            .withColumnRenamed("hashtag", "key"))
+              Footprints.updateFootprints(changedNodesWithHashtags
+                                            .withColumnRenamed("hashtag", "key"), tileSource)
 
             val query = tiledNodes.writeStream
               .queryName("tiled hashtag footprints")

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/UserFootprintUpdater.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/UserFootprintUpdater.scala
@@ -117,9 +117,8 @@ object UserFootprintUpdater
               .select('sequence, 'uid, 'lat, 'lon)
 
             val tiledNodes =
-              Footprints.updateFootprints(tileSource,
-                                          changedNodes
-                                            .withColumnRenamed("uid", "key"))
+              Footprints.updateFootprints(changedNodes
+                                            .withColumnRenamed("uid", "key"), tileSource)
 
             val query = tiledNodes.writeStream
               .queryName("tiled user footprints")

--- a/src/common/build.sbt
+++ b/src/common/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   gtGeotools exclude ("com.google.protobuf", "protobuf-java"),
   "com.github.seratch" %% "awscala" % "0.6.1",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
-  sparkHive % "provided",
+  sparkHive % Provided,
   sparkJts,
   gtS3 exclude ("com.google.protobuf", "protobuf-java") exclude ("com.amazonaws", "aws-java-sdk-s3"),
   gtSpark exclude ("com.google.protobuf", "protobuf-java"),
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   circeJava8,
   circeYaml,
   "com.softwaremill.macmemo" %% "macros" % "0.4",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.340" % "provided"
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.340" % Provided
 )
 
 Test / fork := true


### PR DESCRIPTION
Previously, footprints updated from sequences could be missing data, as Scala `Stream`s were being partially consumed prior to data being processed.

This also cleans things up a bit and uses `Set`s to group sequences rather than `Seq`s.