### PR TITLE
Remove explicit schemas

### DIFF
--- a/src/common/src/main/scala/osmesa/common/model/AugmentedDiff.scala
+++ b/src/common/src/main/scala/osmesa/common/model/AugmentedDiff.scala
@@ -1,14 +1,10 @@
 package osmesa.common.model
 
-import com.vividsolutions.jts.{geom => jts}
-import geotrellis.vector.io._
-import geotrellis.vector.{Feature, Geometry => GTGeometry}
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{Row, Encoder => SparkEncoder}
-import org.apache.spark.sql.jts._
-import osmesa.common.ProcessOSM
 import java.sql.Timestamp
+
+import com.vividsolutions.jts.{geom => jts}
+import geotrellis.vector.{Feature, Geometry => GTGeometry}
+import osmesa.common.ProcessOSM
 
 case class AugmentedDiff(sequence: Int,
                          `type`: Byte,
@@ -32,39 +28,6 @@ case class AugmentedDiff(sequence: Int,
                          minorVersion: Boolean)
 
 object AugmentedDiff {
-  lazy val Schema: StructType = StructType(
-    StructField("sequence", IntegerType) ::
-      StructField("type", ByteType, nullable = false) ::
-      StructField("id", LongType, nullable = false) ::
-      StructField("prevGeom", GeometryUDT, nullable = true) ::
-      StructField("geom", GeometryUDT, nullable = true) ::
-      StructField(
-      "prevTags",
-      MapType(StringType, StringType, valueContainsNull = false),
-      nullable = true
-    ) ::
-      StructField(
-      "tags",
-      MapType(StringType, StringType, valueContainsNull = false),
-      nullable = false
-    ) ::
-      StructField("prevChangeset", LongType, nullable = true) ::
-      StructField("changeset", LongType, nullable = false) ::
-      StructField("prevUid", LongType, nullable = true) ::
-      StructField("uid", LongType, nullable = false) ::
-      StructField("prevUser", StringType, nullable = true) ::
-      StructField("user", StringType, nullable = false) ::
-      StructField("prevUpdated", TimestampType, nullable = true) ::
-      StructField("updated", TimestampType, nullable = false) ::
-      StructField("prevVisible", BooleanType, nullable = true) ::
-      StructField("visible", BooleanType, nullable = false) ::
-      StructField("prevVersion", IntegerType, nullable = true) ::
-      StructField("version", IntegerType, nullable = false) ::
-      StructField("minorVersion", BooleanType, nullable = false) ::
-      Nil
-  )
-  lazy val Encoder: SparkEncoder[Row] = RowEncoder(Schema)
-
   def apply(sequence: Int,
             prev: Option[Feature[GTGeometry, ElementWithSequence]],
             curr: Feature[GTGeometry, ElementWithSequence]): AugmentedDiff = {

--- a/src/common/src/main/scala/osmesa/common/model/Change.scala
+++ b/src/common/src/main/scala/osmesa/common/model/Change.scala
@@ -2,7 +2,6 @@ package osmesa.common.model
 
 import java.sql.Timestamp
 
-import org.apache.spark.sql.types._
 import org.joda.time.DateTime
 import osmesa.common.model.Actions.Action
 
@@ -26,40 +25,6 @@ case class Change(id: Long,
                   sequence: Int)
 
 object Change {
-  lazy val Schema = StructType(
-    StructField("id", LongType) ::
-      StructField("type", StringType) ::
-      StructField(
-      "tags",
-      MapType(StringType, StringType, valueContainsNull = true)
-    ) ::
-      StructField("lat", DoubleType) ::
-      StructField("lon", DoubleType) ::
-      StructField(
-      "nds",
-      DataTypes.createArrayType(StructType(StructField("ref", LongType) :: Nil))
-    ) ::
-      StructField(
-      "members",
-      DataTypes.createArrayType(
-        StructType(
-          StructField("type", StringType) ::
-            StructField("ref", LongType) ::
-            StructField("role", StringType) ::
-            Nil
-        )
-      )
-    ) ::
-      StructField("changeset", LongType) ::
-      StructField("timestamp", TimestampType) ::
-      StructField("uid", LongType) ::
-      StructField("user", StringType) ::
-      StructField("version", LongType) ::
-      StructField("visible", BooleanType) ::
-      StructField("sequence", IntegerType) ::
-      Nil
-  )
-
   implicit def stringToTimestamp(s: String): Timestamp =
     Timestamp.from(DateTime.parse(s).toDate.toInstant)
 
@@ -78,7 +43,7 @@ object Change {
     }
     val nds = `type` match {
       case "way" =>
-      Some((node \ "nd").map(Nd.fromXML))
+        Some((node \ "nd").map(Nd.fromXML))
       case _ => None
     }
     val members = `type` match {

--- a/src/common/src/main/scala/osmesa/common/model/Changeset.scala
+++ b/src/common/src/main/scala/osmesa/common/model/Changeset.scala
@@ -6,21 +6,21 @@ import org.joda.time.DateTime
 
 import scala.util.Try
 
-case class Changeset(sequence: Int,
-                     id: Long,
-                     createdAt: Timestamp,
-                     closedAt: Option[Timestamp],
-                     open: Boolean,
-                     numChanges: Int,
-                     user: String,
-                     uid: Long,
-                     minLat: Option[Float],
-                     maxLat: Option[Float],
-                     minLon: Option[Float],
-                     maxLon: Option[Float],
-                     commentsCount: Int,
+case class Changeset(id: Long,
                      tags: Map[String, String],
-                     comments: Seq[ChangesetComment])
+                     createdAt: Timestamp,
+                     open: Boolean,
+                     closedAt: Option[Timestamp],
+                     commentsCount: Int,
+                     minLat: Option[Double],
+                     maxLat: Option[Double],
+                     minLon: Option[Double],
+                     maxLon: Option[Double],
+                     numChanges: Int,
+                     uid: Long,
+                     user: String,
+                     comments: Seq[ChangesetComment],
+                     sequence: Int)
 
 object Changeset {
   implicit def stringToTimestamp(s: String): Timestamp =
@@ -32,10 +32,10 @@ object Changeset {
       case ts => Some(ts)
     }
 
-  implicit def stringToOptionalFloat(s: String): Option[Float] =
+  implicit def stringToOptionalDouble(s: String): Option[Double] =
     s match {
       case "" => None
-      case c  => Some(c.toFloat)
+      case c  => Some(c.toDouble)
     }
 
   def fromXML(node: scala.xml.Node, sequence: Int): Changeset = {
@@ -57,20 +57,22 @@ object Changeset {
       (node \ "tag").map(tag => (tag \@ "k", tag \@ "v")).toMap
     val comments = (node \ "discussion" \ "comment").map(ChangesetComment.fromXML)
 
-    Changeset(sequence,
-              id,
-              createdAt,
-              closedAt,
-              open,
-              numChanges,
-              user,
-              uid,
-              minLat,
-              maxLat,
-              minLon,
-              maxLon,
-              commentsCount,
-              tags,
-              comments)
+    Changeset(
+      id,
+      tags,
+      createdAt,
+      open,
+      closedAt,
+      commentsCount,
+      minLat,
+      maxLat,
+      minLon,
+      maxLon,
+      numChanges,
+      uid,
+      user,
+      comments,
+      sequence
+    )
   }
 }

--- a/src/common/src/main/scala/osmesa/common/model/Changeset.scala
+++ b/src/common/src/main/scala/osmesa/common/model/Changeset.scala
@@ -2,7 +2,6 @@ package osmesa.common.model
 
 import java.sql.Timestamp
 
-import org.apache.spark.sql.types._
 import org.joda.time.DateTime
 
 import scala.util.Try
@@ -24,41 +23,6 @@ case class Changeset(sequence: Int,
                      comments: Seq[ChangesetComment])
 
 object Changeset {
-  lazy val Schema = StructType(
-    StructField("sequence", IntegerType) ::
-      StructField("id", LongType) ::
-      StructField("createdAt", TimestampType, nullable = false) ::
-      StructField("closedAt", TimestampType, nullable = true) ::
-      StructField("open", BooleanType, nullable = false) ::
-      StructField("numChanges", IntegerType, nullable = false) ::
-      StructField("user", StringType, nullable = false) ::
-      StructField("uid", LongType, nullable = false) ::
-      StructField("minLat", FloatType, nullable = true) ::
-      StructField("maxLat", FloatType, nullable = true) ::
-      StructField("minLon", FloatType, nullable = true) ::
-      StructField("maxLon", FloatType, nullable = true) ::
-      StructField("commentsCount", IntegerType, nullable = false) ::
-      StructField(
-        "tags",
-        MapType(StringType, StringType, valueContainsNull = false),
-        nullable = false
-    ) ::
-      StructField(
-      "comments",
-      DataTypes.createArrayType(
-        StructType(
-          StructField("date", TimestampType, nullable = false) ::
-            StructField("user", StringType, nullable = false) ::
-            StructField("uid", LongType, nullable = false) ::
-            StructField("body", StringType, nullable = false) ::
-              Nil
-        )
-      ),
-      nullable = true
-    ) ::
-      Nil
-  )
-
   implicit def stringToTimestamp(s: String): Timestamp =
     Timestamp.from(DateTime.parse(s).toDate.toInstant)
 

--- a/src/common/src/main/scala/osmesa/common/sources/AugmentedDiffMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/AugmentedDiffMicroBatchReader.scala
@@ -6,7 +6,6 @@ import java.util
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.{DataReader, DataReaderFactory}
-import org.apache.spark.sql.types._
 import osmesa.common.model.AugmentedDiff
 
 import scala.collection.JavaConverters._
@@ -21,23 +20,15 @@ case class AugmentedDiffStreamBatchTask(baseURI: URI, sequences: Seq[Int])
 case class AugmentedDiffStreamBatchReader(baseURI: URI, sequences: Seq[Int])
     extends ReplicationStreamBatchReader[AugmentedDiff](baseURI, sequences) {
 
-  override def schema: StructType = AugmentedDiff.Schema
-
   override def getSequence(baseURI: URI, sequence: Int): Seq[AugmentedDiff] =
     AugmentedDiffSource.getSequence(baseURI, sequence)
 }
 
 case class AugmentedDiffMicroBatchReader(options: DataSourceOptions, checkpointLocation: String)
-    extends ReplicationStreamMicroBatchReader(options, checkpointLocation) {
+    extends ReplicationStreamMicroBatchReader[AugmentedDiff](options, checkpointLocation) {
 
   override def getCurrentSequence: Option[Int] =
     AugmentedDiffSource.getCurrentSequence(baseURI)
-
-  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
-    sequenceRange
-      .map(seq =>
-        AugmentedDiffStreamBatchTask(baseURI, Seq(seq)).asInstanceOf[DataReaderFactory[Row]])
-      .asJava
 
   private def baseURI: URI =
     options
@@ -50,5 +41,9 @@ case class AugmentedDiffMicroBatchReader(options: DataSourceOptions, checkpointL
         )
       )
 
-  override def readSchema(): StructType = AugmentedDiff.Schema
+  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
+    sequenceRange
+      .map(seq =>
+        AugmentedDiffStreamBatchTask(baseURI, Seq(seq)).asInstanceOf[DataReaderFactory[Row]])
+      .asJava
 }

--- a/src/common/src/main/scala/osmesa/common/sources/AugmentedDiffReader.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/AugmentedDiffReader.scala
@@ -6,16 +6,14 @@ import java.util
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.DataReaderFactory
-import org.apache.spark.sql.types.StructType
 import osmesa.common.model.AugmentedDiff
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.util.Random
 
-case class AugmentedDiffReader(options: DataSourceOptions) extends ReplicationReader(options) {
-  override def readSchema(): StructType = AugmentedDiff.Schema
-
+case class AugmentedDiffReader(options: DataSourceOptions)
+    extends ReplicationReader[AugmentedDiff](options) {
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] = {
     // prevent sequential diffs from being assigned to the same task
     val sequences = Random.shuffle((startSequence to endSequence).toList)

--- a/src/common/src/main/scala/osmesa/common/sources/ChangeMicroBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/ChangeMicroBatchReader.scala
@@ -6,13 +6,11 @@ import java.util
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.{DataReader, DataReaderFactory}
-import org.apache.spark.sql.types._
 import osmesa.common.model.Change
 
 import scala.collection.JavaConverters._
 
-case class ChangeStreamBatchTask(baseURI: URI, sequences: Seq[Int])
-    extends DataReaderFactory[Row] {
+case class ChangeStreamBatchTask(baseURI: URI, sequences: Seq[Int]) extends DataReaderFactory[Row] {
   override def createDataReader(): DataReader[Row] =
     new ChangeStreamBatchReader(baseURI, sequences)
 }
@@ -20,28 +18,25 @@ case class ChangeStreamBatchTask(baseURI: URI, sequences: Seq[Int])
 class ChangeStreamBatchReader(baseURI: URI, sequences: Seq[Int])
     extends ReplicationStreamBatchReader[Change](baseURI, sequences) {
 
-  override val schema: StructType = Change.Schema
-
   override def getSequence(baseURI: URI, sequence: Int): Seq[Change] =
     ChangeSource.getSequence(baseURI, sequence)
 }
 
-case class ChangeMicroBatchReader(options: DataSourceOptions,
-                             checkpointLocation: String)
-    extends ReplicationStreamMicroBatchReader(options, checkpointLocation) {
+case class ChangeMicroBatchReader(options: DataSourceOptions, checkpointLocation: String)
+    extends ReplicationStreamMicroBatchReader[Change](options, checkpointLocation) {
   private val baseURI = new URI(
-    options.get(Source.BaseURI)
+    options
+      .get(Source.BaseURI)
       .orElse("https://planet.osm.org/replication/minute/")
   )
 
   override def getCurrentSequence: Option[Int] =
     ChangeSource.getCurrentSequence(baseURI)
 
-  override def readSchema(): StructType = Change.Schema
-
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
-    sequenceRange.map(
-      seq => ChangeStreamBatchTask(baseURI, Seq(seq)).asInstanceOf[DataReaderFactory[Row]]
+    sequenceRange
+      .map(
+        seq => ChangeStreamBatchTask(baseURI, Seq(seq)).asInstanceOf[DataReaderFactory[Row]]
       )
       .asJava
 }

--- a/src/common/src/main/scala/osmesa/common/sources/ChangeReader.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/ChangeReader.scala
@@ -6,15 +6,12 @@ import java.util
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.DataReaderFactory
-import org.apache.spark.sql.types.StructType
 import osmesa.common.model.Change
 
 import scala.collection.JavaConverters._
 import scala.util.Random
 
-case class ChangeReader(options: DataSourceOptions) extends ReplicationReader(options) {
-  override def readSchema(): StructType = Change.Schema
-
+case class ChangeReader(options: DataSourceOptions) extends ReplicationReader[Change](options) {
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] = {
     // prevent sequential diffs from being assigned to the same task
     val sequences = Random.shuffle((startSequence to endSequence).toList)

--- a/src/common/src/main/scala/osmesa/common/sources/ChangesetReader.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/ChangesetReader.scala
@@ -6,15 +6,13 @@ import java.util
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.DataReaderFactory
-import org.apache.spark.sql.types.StructType
 import osmesa.common.model.Changeset
 
 import scala.collection.JavaConverters._
 import scala.util.Random
 
-case class ChangesetReader(options: DataSourceOptions) extends ReplicationReader(options) {
-  override def readSchema(): StructType = Changeset.Schema
-
+case class ChangesetReader(options: DataSourceOptions)
+    extends ReplicationReader[Changeset](options) {
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] = {
     // prevent sequential diffs from being assigned to the same task
     val sequences = Random.shuffle((startSequence to endSequence).toList)

--- a/src/common/src/main/scala/osmesa/common/sources/ReplicationStreamBatchReader.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/ReplicationStreamBatchReader.scala
@@ -4,13 +4,8 @@ import java.net.URI
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.sources.v2.reader.DataReader
-import org.apache.spark.sql.types.StructType
-import osmesa.common.ProcessOSM
-import osmesa.common.model.AugmentedDiff
 
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.concurrent.forkjoin.ForkJoinPool
@@ -21,12 +16,11 @@ abstract class ReplicationStreamBatchReader[T <: Product: TypeTag](baseURI: URI,
     extends DataReader[Row]
     with Logging {
   org.apache.spark.sql.jts.registerTypes()
-  private lazy val rowEncoder = RowEncoder(schema).resolveAndBind()
+  private lazy val rowEncoder = RowEncoder(encoder.schema).resolveAndBind()
   protected var index: Int = -1
   protected var items: Vector[T] = _
   val Concurrency: Int = 8
-  protected def schema: StructType
-  private val encoder = ExpressionEncoder[T]
+  private lazy val encoder = ExpressionEncoder[T]
 
   override def next(): Boolean = {
     index += 1


### PR DESCRIPTION
This will limit the ability for schemas to get out of sync with case classes used to represent data.