### PR TITLE
Modify ChangesetStats to produced normalized data

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
@@ -10,7 +10,6 @@ import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.locationtech.geomesa.spark.jts.st_length
 import osmesa.analytics.Analytics
 import osmesa.common.ProcessOSM
-import osmesa.common.sources.Source
 import osmesa.common.functions._
 import osmesa.common.functions.osm._
 
@@ -172,12 +171,7 @@ object ChangesetStats extends CommandApp(
         .drop('way_countries)
         .drop('node_countries)
 
-      val changesets = spark.read
-                            .format(Source.Changesets)
-                            .option(Source.BaseURI, "http://10.0.1.244/replication/replication/changesets/")
-                            .option(Source.ProcessName, "ChangesetStats")
-                            .load
-      // val changesets = spark.read.orc(changesetSource)
+       val changesets = spark.read.orc(changesetSource)
 
       val changesetMetadata = changesets
         .select(
@@ -185,91 +179,69 @@ object ChangesetStats extends CommandApp(
           'uid,
           'user as 'name,
           'tags.getItem("created_by") as 'editor,
-          'createdAt as 'created_at,
-          'closedAt as 'closed_at,
+          'created_at,
+          'closed_at,
           hashtags('tags) as 'hashtags
         )
 
       val changesetStats = rawChangesetStats
         .join(changesetMetadata, Seq("changeset"), "left_outer")
+        .withColumnRenamed("changeset", "id")
+        .cache
 
-      changesetStats
-        .repartition(50)
+      val changesetsCountriesTable = changesetStats
+        .select('id as 'changeset_id, explode('countries) as Seq("country", "edit_count"))
+
+      val hashtagsTable = changesetStats
+        .select(explode('hashtags) as 'hashtag)
+        .distinct
+        .select(row_number() over Window.orderBy('hashtag) as 'id, 'hashtag)
+        .cache
+
+      val changesetsHashtagsTable = changesetStats
+        .select('id as 'changeset_id, explode('hashtags) as 'hashtag)
+        .join(broadcast(hashtagsTable.withColumnRenamed("id", "hashtag_id")), Seq("hashtag"))
+        .drop('hashtag)
+
+      val usersTable = changesetStats
+        .select('uid as 'id, 'name)
+        .distinct
+
+      val changesetsTable = changesetStats
+        .withColumnRenamed("uid", "user_id")
+        .drop('countries)
+        .drop('hashtags)
+        .drop('name)
+
+      changesetsTable
+        .repartition(1)
         .write
         .mode(SaveMode.Overwrite)
-        .orc(output.resolve("changesets").toString)
-      //
-      //      val userStats = changesetStats
-      //        .groupBy('uid, 'name)
-      //        .agg(
-      //          sum('road_km_added) as 'road_km_added,
-      //          sum('road_km_modified) as 'road_km_modified,
-      //          sum('waterway_km_added) as 'waterway_km_added,
-      //          sum('waterway_km_modified) as 'waterway_km_modified,
-      //          sum('coastline_km_added) as 'coastline_km_added,
-      //          sum('coastline_km_modified) as 'coastline_km_modified,
-      //          sum('roads_added) as 'roads_added,
-      //          sum('roads_modified) as 'roads_modified,
-      //          sum('waterways_added) as 'waterways_added,
-      //          sum('waterways_modified) as 'waterways_modified,
-      //          sum('coastlines_added) as 'coastlines_added,
-      //          sum('coastlines_modified) as 'coastlines_modified,
-      //          sum('buildings_added) as 'buildings_added,
-      //          sum('buildings_modified) as 'buildings_modified,
-      //          sum('pois_added) as 'pois_added,
-      //          sum('pois_modified) as 'pois_modified,
-      //          count('changeset) as 'changeset_count,
-      //          // TODO more efficient as a UDAF; even more efficient using mapPartitions
-      //          count_values(collect_list('editor)) as 'editors,
-      //          count_values(collect_list(to_date(date_trunc("day", 'created_at)))) as 'edit_times,
-      //          count_values(flatten(collect_list('hashtags))) as 'hashtags,
-      //          sum_counts(collect_list('countries)) as 'countries
-      //        )
-      //        .withColumn("edit_count", ('roads_added + 'roads_modified + 'waterways_added + 'waterways_modified +
-      //          'coastlines_added + 'coastlines_modified + 'buildings_added + 'buildings_modified + 'pois_added + 'pois_modified) as 'edit_count)
-      //
-      //      val hashtagStats = changesetStats
-      //        .withColumn("hashtag", explode('hashtags))
-      //        .groupBy('hashtag)
-      //        .agg(
-      //          sum('road_km_added) as 'road_km_added,
-      //          sum('road_km_modified) as 'road_km_modified,
-      //          sum('waterway_km_added) as 'waterway_km_added,
-      //          sum('waterway_km_modified) as 'waterway_km_modified,
-      //          sum('coastline_km_added) as 'coastline_km_added,
-      //          sum('coastline_km_modified) as 'coastline_km_modified,
-      //          sum('roads_added) as 'roads_added,
-      //          sum('roads_modified) as 'roads_modified,
-      //          sum('waterways_added) as 'waterways_added,
-      //          sum('waterways_modified) as 'waterways_modified,
-      //          sum('coastlines_added) as 'coastlines_added,
-      //          sum('coastlines_modified) as 'coastlines_modified,
-      //          sum('buildings_added) as 'buildings_added,
-      //          sum('buildings_modified) as 'buildings_modified,
-      //          sum('pois_added) as 'pois_added,
-      //          sum('pois_modified) as 'pois_modified,
-      //          count('changeset) as 'changeset_count,
-      //          count_values(collect_list('editor)) as 'editors,
-      //          count_values(collect_list(to_date(date_trunc("day", 'created_at)))) as 'edit_times,
-      //          flatten(collect_list('hashtags)) as 'hashtags,
-      //          sum_counts(collect_list('countries)) as 'countries
-      //        )
-      //        .withColumn("edit_count", ('roads_added + 'roads_modified + 'waterways_added + 'waterways_modified +
-      //          'coastlines_added + 'coastlines_modified + 'buildings_added + 'buildings_modified + 'pois_added + 'pois_modified) as 'edit_count)
-      //        .withColumn("related_hashtags", count_values(without('hashtags, 'hashtag)))
-      //        .drop('hashtags)
-      //
-      //      userStats
-      //        .repartition(1)
-      //        .write
-      //        .mode(SaveMode.Overwrite)
-      //        .orc(output.resolve("user-stats").toString)
-      //
-      //      hashtagStats
-      //        .repartition(1)
-      //        .write
-      //        .mode(SaveMode.Overwrite)
-      //        .orc(output.resolve("hashtag-stats").toString)
+        .csv(output.resolve("changesets").toString)
+
+      changesetsCountriesTable
+        .repartition(1)
+        .write
+        .mode(SaveMode.Overwrite)
+        .csv(output.resolve("changesets_countries").toString)
+
+      changesetsHashtagsTable
+        .repartition(1)
+        .write
+        .mode(SaveMode.Overwrite)
+        .csv(output.resolve("changesets_hashtags").toString)
+
+      hashtagsTable
+        .repartition(1)
+        .write
+        .mode(SaveMode.Overwrite)
+        .csv(output.resolve("hashtags").toString)
+
+      usersTable
+        .repartition(1)
+        .write
+        .mode(SaveMode.Overwrite)
+        .csv(output.resolve("users").toString)
 
       spark.stop()
     }

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
@@ -181,7 +181,7 @@ object ChangesetStats extends CommandApp(
           'tags.getItem("created_by") as 'editor,
           'created_at,
           'closed_at,
-          hashtags('tags) as 'hashtags
+          hashtags('tags.getField("comment")) as 'hashtags
         )
 
       val changesetStats = rawChangesetStats

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStreamProcessor.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStreamProcessor.scala
@@ -6,7 +6,6 @@ import java.sql.{Connection, Timestamp}
 import cats.implicits._
 import com.monovore.decline._
 import org.apache.spark.sql._
-import org.locationtech.geomesa.spark.jts._
 import osmesa.analytics.Analytics
 import osmesa.common.functions.osm._
 import osmesa.common.sources.Source
@@ -85,7 +84,7 @@ object ChangesetStreamProcessor extends CommandApp(
                   'user,
                   'uid,
                   'tags.getField("created_by") as 'editor,
-                  hashtags('tags) as 'hashtags)
+                  hashtags('tags.getField("comment")) as 'hashtags)
           .writeStream
           .queryName("update changeset metadata")
           .foreach(new ForeachWriter[Row] {

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/Footprint.scala
@@ -93,7 +93,7 @@ object Footprint extends Logging {
               }.toString)
 
           val targetUsers = changesets
-            .withColumn("hashtag", explode(hashtags('tags)))
+            .withColumn("hashtag", explode(hashtags('tags.getField("comment"))))
             .where('hashtag isin (targetHashtags.toSeq: _*))
             .select('uid)
             .distinct
@@ -111,8 +111,8 @@ object Footprint extends Logging {
           val changesets =
             spark.read
               .orc(changesetsURI.toString)
-              .where(size(hashtags('tags)) > 0)
-              .withColumn("hashtag", explode(hashtags('tags)))
+              .where(size(hashtags('tags.getField("comment"))) > 0)
+              .withColumn("hashtag", explode(hashtags('tags.getField("comment"))))
               .withColumnRenamed("id", "changeset")
 
           spark.read
@@ -128,7 +128,7 @@ object Footprint extends Logging {
               .withColumnRenamed("id", "changeset")
 
           val targetChangesets = changesets
-            .withColumn("hashtag", explode(hashtags('tags)))
+            .withColumn("hashtag", explode(hashtags('tags.getField("comment"))))
             .where('hashtag isin (targetHashtags.toSeq: _*))
             .select('changeset, 'hashtag)
             .distinct

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/HashtagFootprintUpdater.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/HashtagFootprintUpdater.scala
@@ -173,7 +173,7 @@ object HashtagFootprintUpdater
               // TODO can projecting into the future (createdAt + 24 hours) and coalescing closedAt reduce the number
               // of changesets being tracked?
               .withWatermark("createdAt", "25 hours")
-              .withColumn("hashtag", explode(hashtags('tags)))
+              .withColumn("hashtag", explode(hashtags('tags.getField("comment"))))
               .select('sequence, 'id as 'changeset, 'hashtag)
 
             val changedNodes = changes

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/MergedChangesetStreamProcessor.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/MergedChangesetStreamProcessor.scala
@@ -141,7 +141,7 @@ object MergedChangesetStreamProcessor extends CommandApp(
           .select(
             'id as 'changeset,
             'tags.getField("created_by") as 'editor,
-            hashtags('tags) as 'hashtags
+            hashtags('tags.getField("comment")) as 'hashtags
           )
 
         val geomsWithWatermark = geoms

--- a/src/common/src/main/scala/osmesa/common/functions/osm/package.scala
+++ b/src/common/src/main/scala/osmesa/common/functions/osm/package.scala
@@ -198,9 +198,9 @@ package object osm {
       .toList // prevent a Stream from being returned
   }
 
-  def hashtags(tags: Column): Column =
+  def hashtags(comment: Column): Column =
     // only call the UDF when necessary
-    when(tags.getField("comment").isNotNull, extractHashtags(tags.getField("comment")))
+    when(comment.isNotNull and length(comment) > 0, extractHashtags(comment))
       .otherwise(typedLit(Seq.empty[String])) as "hashtags"
 
   def isBuilding(tags: Column): Column =

--- a/src/common/src/main/scala/osmesa/common/functions/osm/package.scala
+++ b/src/common/src/main/scala/osmesa/common/functions/osm/package.scala
@@ -148,17 +148,17 @@ package object osm {
     when(lower(coalesce(tags.getField("area"), lit(""))).isin(BooleanValues: _*),
          lower(tags.getField("area")).isin(TruthyValues: _*))
       // only call the UDF when necessary
-      .otherwise(isAreaUDF(tags)) as "isArea"
+      .otherwise(isAreaUDF(tags)) as 'isArea
 
   def isMultiPolygon(tags: Column): Column =
     lower(coalesce(tags.getItem("type"), lit("")))
-      .isin(MultiPolygonTypes: _*) as "isMultiPolygon"
+      .isin(MultiPolygonTypes: _*) as 'isMultiPolygon
 
   def isNew(version: Column, minorVersion: Column): Column =
-    version <=> 1 && minorVersion <=> 0 as "isNew"
+    version <=> 1 && minorVersion <=> 0 as 'isNew
 
   def isRoute(tags: Column): Column =
-    lower(tags.getItem("type")) <=> "route" as "isRoute"
+    lower(tags.getItem("type")) <=> "route" as 'isRoute
 
   private lazy val MemberSchema = ArrayType(
     StructType(
@@ -201,24 +201,24 @@ package object osm {
   def hashtags(comment: Column): Column =
     // only call the UDF when necessary
     when(comment.isNotNull and length(comment) > 0, extractHashtags(comment))
-      .otherwise(typedLit(Seq.empty[String])) as "hashtags"
+      .otherwise(typedLit(Seq.empty[String])) as 'hashtags
 
   def isBuilding(tags: Column): Column =
-    lower(coalesce(tags.getItem("building"), lit("no"))) =!= "no" as "isBuilding"
+    lower(coalesce(tags.getItem("building"), lit("no"))) =!= "no" as 'isBuilding
 
   val isPOI: UserDefinedFunction = udf {
     tags: Map[String, String] => POITags.intersect(tags.keySet).nonEmpty
   }
 
   def isRoad(tags: Column): Column =
-    array_contains(map_keys(tags), "highway") as "isRoad"
+    tags.getItem("highway").isNotNull as 'isRoad
 
   def isCoastline(tags: Column): Column =
-    lower(tags.getItem("natural")) <=> "coastline" as "isCoastline"
+    lower(tags.getItem("natural")) <=> "coastline" as 'isCoastline
 
   def isWaterway(tags: Column): Column =
     lower(coalesce(tags.getItem("waterway"), lit("")))
-      .isin(WaterwayValues: _*) as "isWaterway"
+      .isin(WaterwayValues: _*) as 'isWaterway
 
   def mergeTags: UserDefinedFunction = udf {
     (_: Map[String, String]) ++ (_: Map[String, String])

--- a/src/common/src/main/scala/osmesa/common/functions/package.scala
+++ b/src/common/src/main/scala/osmesa/common/functions/package.scala
@@ -1,9 +1,9 @@
 package osmesa.common
 
-import java.math.BigDecimal
-
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DoubleType, FloatType}
 import osmesa.common.util._
 
 package object functions {
@@ -19,15 +19,15 @@ package object functions {
 
   // Convert BigDecimals to doubles
   // Reduces size taken for representation at the expense of some precision loss.
-  val asDouble: UserDefinedFunction = udf {
-    Option(_: BigDecimal).map(_.doubleValue).getOrElse(Double.NaN)
-  }
+  def asDouble(value: Column): Column =
+    when(value.isNotNull, value.cast(DoubleType))
+      .otherwise(lit(Double.NaN)) as s"asDouble($value)"
 
   // Convert BigDecimals to floats
   // Reduces size taken for representation at the expense of more precision loss.
-  val asFloat: UserDefinedFunction = udf {
-    Option(_: BigDecimal).map(_.floatValue).getOrElse(Float.NaN)
-  }
+  def asFloat(value: Column): Column =
+    when(value.isNotNull, value.cast(FloatType))
+      .otherwise(lit(Float.NaN)) as s"asFloat($value)"
 
   val count_values: UserDefinedFunction = udf {
     (_: Seq[String]).groupBy(identity).mapValues(_.size)


### PR DESCRIPTION
This makes it easier to populate an empty database with backfilled statistics.

A number of UDFs were rewritten as functions operating on `Column`s to improve performance (no need to fully deserialize when using the latter).