### PR TITLE
Track deletes and distinguish from modifications

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/ChangesetStats.scala
@@ -69,68 +69,100 @@ object ChangesetStats extends CommandApp(
           when(isRoad('tags) and isNew('version, 'minorVersion), 'length)
             .otherwise(lit(0)))
         .withColumn("road_m_modified",
-          when(isRoad('tags) and not(isNew('version, 'minorVersion)), 'delta)
+          when(isRoad('tags) and not(isNew('version, 'minorVersion)) and 'visible, 'delta)
+            .otherwise(lit(0)))
+        .withColumn("road_m_deleted",
+          when(isRoad('tags) and !'visible, 'delta)
             .otherwise(lit(0)))
         .withColumn("waterway_m_added",
           when(isWaterway('tags) and isNew('version, 'minorVersion), 'length)
             .otherwise(lit(0)))
         .withColumn("waterway_m_modified",
-          when(isWaterway('tags) and not(isNew('version, 'minorVersion)), 'delta)
+          when(isWaterway('tags) and not(isNew('version, 'minorVersion)) and 'visible, 'delta)
+            .otherwise(lit(0)))
+        .withColumn("waterway_m_deleted",
+          when(isWaterway('tags) and !'visible, 'delta)
             .otherwise(lit(0)))
         .withColumn("coastline_m_added",
           when(isCoastline('tags) and isNew('version, 'minorVersion), 'length)
             .otherwise(lit(0)))
         .withColumn("coastline_m_modified",
-          when(isCoastline('tags) and not(isNew('version, 'minorVersion)), 'delta)
+          when(isCoastline('tags) and not(isNew('version, 'minorVersion)) and 'visible, 'delta)
+            .otherwise(lit(0)))
+        .withColumn("coastline_m_deleted",
+          when(isCoastline('tags) and !'visible, 'delta)
             .otherwise(lit(0)))
         .withColumn("roads_added",
           when(isRoad('tags) and isNew('version, 'minorVersion), lit(1))
             .otherwise(lit(0)))
         .withColumn("roads_modified",
-          when(isRoad('tags) and not(isNew('version, 'minorVersion)), lit(1))
+          when(isRoad('tags) and not(isNew('version, 'minorVersion)) and 'visible, lit(1))
+            .otherwise(lit(0)))
+        .withColumn("roads_deleted",
+          when(isRoad('tags) and !'visible, lit(1))
             .otherwise(lit(0)))
         .withColumn("waterways_added",
           when(isWaterway('tags) and isNew('version, 'minorVersion), lit(1))
             .otherwise(lit(0)))
         .withColumn("waterways_modified",
-          when(isWaterway('tags) and not(isNew('version, 'minorVersion)), lit(1))
+          when(isWaterway('tags) and not(isNew('version, 'minorVersion)) and 'visible, lit(1))
+            .otherwise(lit(0)))
+        .withColumn("waterways_deleted",
+          when(isWaterway('tags) and !'visible, lit(1))
             .otherwise(lit(0)))
         .withColumn("coastlines_added",
           when(isCoastline('tags) and isNew('version, 'minorVersion), lit(1))
             .otherwise(lit(0)))
         .withColumn("coastlines_modified",
-          when(isCoastline('tags) and not(isNew('version, 'minorVersion)), lit(1))
+          when(isCoastline('tags) and not(isNew('version, 'minorVersion)) and 'visible, lit(1))
+            .otherwise(lit(0)))
+        .withColumn("coastlines_deleted",
+          when(isCoastline('tags) and !'visible, lit(1))
             .otherwise(lit(0)))
         .withColumn("buildings_added",
           when(isBuilding('tags) and isNew('version, 'minorVersion), lit(1))
             .otherwise(lit(0)))
         .withColumn("buildings_modified",
-          when(isBuilding('tags) and not(isNew('version, 'minorVersion)), lit(1))
+          when(isBuilding('tags) and not(isNew('version, 'minorVersion)) and 'visible, lit(1))
+            .otherwise(lit(0)))
+        .withColumn("buildings_deleted",
+          when(isBuilding('tags) and !'visible, lit(1))
             .otherwise(lit(0)))
         .withColumn("pois_added",
           when(isPOI('tags) and isNew('version, 'minorVersion), lit(1))
             .otherwise(lit(0)))
         .withColumn("pois_modified",
-          when(isPOI('tags) and not(isNew('version, 'minorVersion)), lit(1))
+          when(isPOI('tags) and not(isNew('version, 'minorVersion)) and 'visible, lit(1))
+            .otherwise(lit(0)))
+        .withColumn("pois_deleted",
+          when(isPOI('tags) and !'visible, lit(1))
             .otherwise(lit(0)))
         .groupBy('changeset)
         .agg(
           sum('road_m_added / 1000).as('road_km_added),
           sum('road_m_modified / 1000).as('road_km_modified),
+          sum('road_m_deleted / 1000).as('road_km_deleted),
           sum('waterway_m_added / 1000).as('waterway_km_added),
           sum('waterway_m_modified / 1000).as('waterway_km_modified),
+          sum('waterway_m_deleted / 1000).as('waterway_km_deleted),
           sum('coastline_m_added / 1000).as('coastline_km_added),
           sum('coastline_m_modified / 1000).as('coastline_km_modified),
+          sum('coastline_m_deleted / 1000).as('coastline_km_deleted),
           sum('roads_added).as('roads_added),
           sum('roads_modified).as('roads_modified),
+          sum('roads_deleted).as('roads_deleted),
           sum('waterways_added).as('waterways_added),
           sum('waterways_modified).as('waterways_modified),
+          sum('waterways_deleted).as('waterways_deleted),
           sum('coastlines_added).as('coastlines_added),
           sum('coastlines_modified).as('coastlines_modified),
+          sum('coastlines_deleted).as('coastlines_deleted),
           sum('buildings_added).as('buildings_added),
           sum('buildings_modified).as('buildings_modified),
+          sum('buildings_deleted).as('buildings_deleted),
           sum('pois_added).as('pois_added),
           sum('pois_modified).as('pois_modified),
+          sum('pois_deleted).as('pois_deleted),
           count_values(flatten(collect_list('countries))) as 'countries
         )
 
@@ -139,12 +171,16 @@ object ChangesetStats extends CommandApp(
           when(isPOI('tags) and 'version === 1, lit(1))
             .otherwise(lit(0)))
         .withColumn("pois_modified",
-          when(isPOI('tags) and 'version > 1, lit(1))
+          when(isPOI('tags) and 'version > 1 and 'visible, lit(1))
+            .otherwise(lit(0)))
+        .withColumn("pois_deleted",
+          when(isPOI('tags) and !'visible, lit(1))
             .otherwise(lit(0)))
         .groupBy('changeset)
         .agg(
           sum('pois_added) as 'pois_added,
           sum('pois_modified) as 'pois_modified,
+          sum('pois_modified) as 'pois_deleted,
           count_values(flatten(collect_list('countries))) as 'countries
         )
 
@@ -152,36 +188,49 @@ object ChangesetStats extends CommandApp(
       val rawChangesetStats = wayChangesetStats
         .withColumnRenamed("pois_added", "way_pois_added")
         .withColumnRenamed("pois_modified", "way_pois_modified")
+        .withColumnRenamed("pois_deleted", "way_pois_deleted")
         .withColumnRenamed("countries", "way_countries")
         .join(pointChangesetStats
           .withColumnRenamed("pois_added", "node_pois_added")
           .withColumnRenamed("pois_modified", "node_pois_modified")
+          .withColumnRenamed("pois_deleted", "node_pois_deleted")
           .withColumnRenamed("countries", "node_countries"),
           Seq("changeset"),
           "full_outer")
         .withColumn("road_km_added", coalesce('road_km_added, lit(0)))
         .withColumn("road_km_modified", coalesce('road_km_modified, lit(0)))
+        .withColumn("road_km_deleted", coalesce('road_km_deleted, lit(0)))
         .withColumn("waterway_km_added", coalesce('waterway_km_added, lit(0)))
         .withColumn("waterway_km_modified", coalesce('waterway_km_modified, lit(0)))
+        .withColumn("waterway_km_deleted", coalesce('waterway_km_deleted, lit(0)))
         .withColumn("coastline_km_added", coalesce('coastline_km_added, lit(0)))
         .withColumn("coastline_km_modified", coalesce('coastline_km_modified, lit(0)))
+        .withColumn("coastline_km_deleted", coalesce('coastline_km_deleted, lit(0)))
         .withColumn("roads_added", coalesce('roads_added, lit(0)))
         .withColumn("roads_modified", coalesce('roads_modified, lit(0)))
+        .withColumn("roads_deleted", coalesce('roads_deleted, lit(0)))
         .withColumn("waterways_added", coalesce('waterways_added, lit(0)))
         .withColumn("waterways_modified", coalesce('waterways_modified, lit(0)))
+        .withColumn("waterways_deleted", coalesce('waterways_deleted, lit(0)))
         .withColumn("coastlines_added", coalesce('coastlines_added, lit(0)))
         .withColumn("coastlines_modified", coalesce('coastlines_modified, lit(0)))
+        .withColumn("coastlines_deleted", coalesce('coastlines_deleted, lit(0)))
         .withColumn("buildings_added", coalesce('buildings_added, lit(0)))
         .withColumn("buildings_modified", coalesce('buildings_modified, lit(0)))
+        .withColumn("buildings_deleted", coalesce('buildings_deleted, lit(0)))
         .withColumn("pois_added",
           coalesce('way_pois_added, lit(0)) + coalesce('node_pois_added, lit(0)))
         .withColumn("pois_modified",
           coalesce('way_pois_modified, lit(0)) + coalesce('node_pois_modified, lit(0)))
+        .withColumn("pois_deleted",
+          coalesce('way_pois_deleted, lit(0)) + coalesce('node_pois_deleted, lit(0)))
         .withColumn("countries", merge_counts('node_countries, 'way_countries))
         .drop('way_pois_added)
         .drop('node_pois_added)
         .drop('way_pois_modified)
         .drop('node_pois_modified)
+        .drop('way_pois_deleted)
+        .drop('node_pois_deleted)
         .drop('way_countries)
         .drop('node_countries)
 


### PR DESCRIPTION
Prior to this PR, tags on deleted elements would be `null`, preventing those elements from being categorized correctly (or at all). By applying a window function to nodes and ways before filtering, the tags present on the version immediately prior to deletion will be used.

This PR also breaks out deletes (otherwise they'd be combined with modifications).