### PR TITLE
Fetch gzipped augmented diff JSON

### DIFF
--- a/src/common/src/main/scala/osmesa/common/sources/ChangeSource.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/ChangeSource.scala
@@ -20,9 +20,8 @@ object ChangeSource extends Logging {
   private val saxParserFactory = SAXParserFactory.newInstance
 
   def getSequence(baseURI: URI, sequence: Int): Seq[Change] = {
-    val s = f"$sequence%09d".toArray
-    val path =
-      s"${s.slice(0, 3).mkString}/${s.slice(3, 6).mkString}/${s.slice(6, 9).mkString}.osc.gz"
+    val s = f"$sequence%09d"
+    val path = s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.osc.gz"
 
     logInfo(s"Fetching sequence $sequence")
 

--- a/src/common/src/main/scala/osmesa/common/sources/ChangesetSource.scala
+++ b/src/common/src/main/scala/osmesa/common/sources/ChangesetSource.scala
@@ -2,6 +2,7 @@ package osmesa.common.sources
 
 import java.io.{ByteArrayInputStream, IOException}
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.util.zip.GZIPInputStream
 
 import cats.implicits._
@@ -27,9 +28,8 @@ object ChangesetSource extends Logging {
     Decoder.instance(a => a.as[String].map(DateTime.parse(_, formatter)))
 
   def getSequence(baseURI: URI, sequence: Int): Seq[Changeset] = {
-    val s = f"$sequence%09d".toArray
-    val path =
-      s"${s.slice(0, 3).mkString}/${s.slice(3, 6).mkString}/${s.slice(6, 9).mkString}.osm.gz"
+    val s = f"$sequence%09d"
+    val path = s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.osm.gz"
 
     logDebug(s"Fetching sequence $sequence")
 
@@ -46,7 +46,7 @@ object ChangesetSource extends Logging {
         val bais = new ByteArrayInputStream(response.body)
         val gzis = new GZIPInputStream(bais)
         try {
-          val data = XML.loadString(IOUtils.toString(gzis))
+          val data = XML.loadString(IOUtils.toString(gzis, StandardCharsets.UTF_8))
 
           val changesets = (data \ "changeset").map(Changeset.fromXML(_, sequence))
 


### PR DESCRIPTION
Path segments are also split up to match partitioning of OSM replication files.

Fixes #122 