### PR TITLE
Reduce MVT granularity

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/EditHistogram.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/EditHistogram.scala
@@ -181,7 +181,7 @@ object EditHistogram extends VectorGrid {
 
                 unmodifiedFeatures ++ replacementFeatures ++ newFeatures match {
                   case updatedFeatures if (replacementFeatures.length + newFeatures.length) > 0 =>
-                    val updatedLayer = makeLayer(key, extent, updatedFeatures)
+                    val updatedLayer = makeLayer(key, extent, updatedFeatures, Cells)
                     val sequenceLayer =
                       makeSequenceLayer(getCommittedSequences(tile) ++ sequences, extent)
 
@@ -191,7 +191,7 @@ object EditHistogram extends VectorGrid {
                     None
                 }
               case None =>
-                Some(makeLayer(key, extent, makeFeatures(feats)),
+                Some(makeLayer(key, extent, makeFeatures(feats), Cells),
                      makeSequenceLayer(sequences, extent))
             }
 
@@ -213,7 +213,7 @@ object EditHistogram extends VectorGrid {
             }
 
           case None =>
-            write(VectorTile(Map(makeLayer(key, extent, makeFeatures(feats)),
+            write(VectorTile(Map(makeLayer(key, extent, makeFeatures(feats), Cells),
                                  makeSequenceLayer(sequences, extent)),
                              extent),
                   uri)

--- a/src/analytics/src/main/scala/osmesa/analytics/updater/package.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/updater/package.scala
@@ -315,12 +315,12 @@ package object updater extends Logging {
     (points, multiPoints, lines, multiLines, polygons, multiPolygons)
   }
 
-  def makeLayer(name: String, extent: Extent, features: Iterable[VTFeature]): (String, Layer) = {
+  def makeLayer(name: String, extent: Extent, features: Iterable[VTFeature], tileWidth: Int = 4096): (String, Layer) = {
     val (points, multiPoints, lines, multiLines, polygons, multiPolygons) = segregate(features)
 
     name -> StrictLayer(
       name = name,
-      tileWidth = 4096,
+      tileWidth = tileWidth,
       version = 2,
       tileExtent = extent,
       points = points,


### PR DESCRIPTION
We're vectorizing 128x128 grids, so a target grid of 128x128 makes more sense than the default 4096x4096 grid.