### PR TITLE
Integrate postgres Notification list with AugmentedDiff source

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/StreamingAOIMonitor.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/StreamingAOIMonitor.scala
@@ -77,7 +77,7 @@ object StreamingAOIMonitor
             notifications.foreach { println(_) }
             val notificationsDf = notifications
               .toDF("notificationId", "userId", "geom", "name", "email")
-            val aoiIndex = AOIIndex(notifications)
+            val aoiIndex = spark.sparkContext.broadcast(AOIIndex(notifications))
 
             lazy val currentSequence = AugmentedDiffSource
               .getCurrentSequence(augmentedDiffSource)
@@ -131,7 +131,7 @@ object StreamingAOIMonitor
             )
 
             val aoiTag = udf { g: jts.Geometry =>
-              aoiIndex(g).toList
+              aoiIndex.value(g).toList
             }
 
             // 1. READ IN DIFF STREAM

--- a/src/analytics/src/main/scala/osmesa/analytics/oneoffs/StreamingAOIMonitor.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/oneoffs/StreamingAOIMonitor.scala
@@ -175,6 +175,8 @@ object StreamingAOIMonitor
             // 4. SEND MESSAGES TO QUEUE
             //    We need to craft an email from each record and queue it for sending
             messageInfo.foreach { info =>
+              warnMessage(
+                s"Message: ${info.notificationId}, ${info.edit_count}, ${info.changeset_count}")
             }
 
             // 5. SAVE CURRENT END POSITION IN DB FOR NEXT RUN
@@ -192,7 +194,7 @@ object AOIMonitorUtils extends Logging {
   type Notification = Feature[Geometry, NotificationData]
 
   case class NotificationSummary(
-      data: NotificationData,
+      notificationId: String,
       edit_count: Long,
       changeset_count: Int
   ) {


### PR DESCRIPTION
The postgres table containing notifications was simplified such that we now just have a Notification table that directly contains each geometry and its name. This is because the MVP prototype specifically describes a notification as relating one to one to an AOI geom. No sense building something more complicated to prove a concept. We can always re-normalize later. Given that we want to just group on notification id. 

The data types were refactored a bit in order to match names to the types a bit better.

Deletes the remaining references/usages to the stubs that provided static geojson data.