### PR TITLE
Update deployment scripts to work for production migrations

### DIFF
--- a/deployment/streaming/Makefile
+++ b/deployment/streaming/Makefile
@@ -1,7 +1,7 @@
 include config-deployment.mk
 
 # If the user is on master branch, see if we should deploy to production
-VERSION_TAG=$(shell ./scripts/get-tag.sh)
+VERSION_TAG:=$(shell ./scripts/get-tag.sh)
 ifeq ($(VERSION_TAG), production)
 	DATABASE=${PRODUCTION_DB}
 	ECS_CLUSTER=${CLUSTER_NAME_DEPLOYMENT}
@@ -58,7 +58,7 @@ deploy-streaming-footprint-updater: stop-streaming-footprint-updater
 	aws ecs create-service \
 	  --cluster "${CLUSTER_NAME_DEPLOYMENT}" \
 	  --service-name "streaming-user-footprint-tile-updater" \
-	  --task-definition "streaming-edit-histogram-tile-updater" \
+	  --task-definition "streaming-user-footprint-tile-updater" \
 	  --desired-count 1 \
 	  --launch-type FARGATE \
 	  --scheduling-strategy REPLICA \

--- a/deployment/streaming/scripts/define-production-streaming-update-tasks.sh
+++ b/deployment/streaming/scripts/define-production-streaming-update-tasks.sh
@@ -6,7 +6,7 @@ if [ -z ${VERSION_TAG+x} ]; then
 fi
 
 aws ecs register-task-definition \
-    --family streaming-stats-updater-production \
+    --family streaming-stats-updater \
     --task-role-arn "arn:aws:iam::${IAM_ACCOUNT}:role/ECSTaskS3" \
     --execution-role-arn "arn:aws:iam::${IAM_ACCOUNT}:role/ecsTaskExecutionRole" \
     --network-mode awsvpc \
@@ -26,7 +26,7 @@ aws ecs register-task-definition \
 	      \"command\": [
 	        \"/spark/bin/spark-submit\",
 	        \"--driver-memory\", \"2048m\",
-	        \"--class\", \"osmesa.analytics.oneoffs.AugmentedDiffStreamProcessor\",
+	        \"--class\", \"osmesa.analytics.oneoffs.StreamingChangesetStatsUpdater\",
 	        \"/opt/osmesa-analytics.jar\",
 	        \"--augmented-diff-source\", \"${AUGDIFF_SOURCE}\"
 	      ],
@@ -51,7 +51,7 @@ aws ecs register-task-definition \
 	      \"command\": [
 	        \"/spark/bin/spark-submit\",
 	        \"--driver-memory\", \"2048m\",
-	        \"--class\", \"osmesa.analytics.oneoffs.ChangesetStreamProcessor\",
+	        \"--class\", \"osmesa.analytics.oneoffs.StreamingChangesetMetadataUpdater\",
 	        \"/opt/osmesa-analytics.jar\",
 	        \"--changeset-source\", \"${CHANGESET_SOURCE}\"
 	      ],

--- a/deployment/streaming/scripts/define-streaming-vectortile-tasks.sh
+++ b/deployment/streaming/scripts/define-streaming-vectortile-tasks.sh
@@ -34,12 +34,23 @@ aws ecs register-task-definition \
 	      \"environment\": [
 	        {
 	          \"name\": \"DATABASE_URL\",
-	          \"value\": \"${DB_BASE_URI}${PRODUCTION_DB}\"
+	          \"value\": \"${DB_BASE_URI}/${PRODUCTION_DB}\"
 	        }
 	      ],
-	      \"image\": \"${ECR_IMAGE}\",
+	      \"image\": \"${ECR_IMAGE}:production\",
 	      \"name\": \"streaming-edit-histogram-tile-updater\"
-	    },
+	    }
+	  ]"
+
+aws ecs register-task-definition \
+    --family streaming-user-footprint-tile-updater \
+    --task-role-arn "arn:aws:iam::${IAM_ACCOUNT}:role/ECSTaskS3" \
+    --execution-role-arn "arn:aws:iam::${IAM_ACCOUNT}:role/ecsTaskExecutionRole" \
+    --network-mode awsvpc \
+    --requires-compatibilities EC2 FARGATE \
+    --cpu "1 vCPU" \
+    --memory "2 GB" \
+    --container-definitions "[
 	    {
 	      \"logConfiguration\": {
 	        \"logDriver\": \"awslogs\",
@@ -54,13 +65,13 @@ aws ecs register-task-definition \
 	        \"--driver-memory\", \"2048m\",
 	        \"--class\", \"osmesa.analytics.oneoffs.StreamingUserFootprintTileUpdater\",
 	        \"/opt/osmesa-analytics.jar\",
-	        \"--change-source\", \"${CHANGESET_SOURCE}\",
+	        \"--change-source\", \"${CHANGE_SOURCE}\",
 	        \"--tile-source\", \"${FOOTPRINT_VT_LOCATION}\"
 	      ],
 	      \"environment\": [
 	        {
 	          \"name\": \"DATABASE_URL\",
-	          \"value\": \"${DB_BASE_URI}${PRODUCTION_DB}\"
+	          \"value\": \"${DB_BASE_URI}/${PRODUCTION_DB}\"
 	        }
 	      ],
 	      \"image\": \"${ECR_IMAGE}:production\",

--- a/deployment/streaming/scripts/get-tag.sh
+++ b/deployment/streaming/scripts/get-tag.sh
@@ -2,16 +2,17 @@
 
 if [ "$(git branch | grep '* master')" = "* master" ]; then
     while true; do
-	echo "You are on the master branch.  Do you wish to publish to the production tag?"
+	>&2 echo "You are on the master branch.  Do you wish to publish to the production tag?"
 	select yn in "Yes" "No"; do
 	    case $yn in
 		Yes ) VERSION_TAG="production"; break;;
 		No ) VERSION_TAG="latest"; break;;
 	    esac
 	done
+        break
     done
 else
     VERSION_TAG="latest"
 fi
 
-echo "${VERSION_TAG}"
+echo -n "${VERSION_TAG}"


### PR DESCRIPTION
In our first migration to production, some bugs in the required scripts were encountered.  This PR fixes those scripts.