### PR TITLE
Send SMTP Emails from StreamingAOIMonitor CLI

### DIFF
--- a/src/analytics/build.sbt
+++ b/src/analytics/build.sbt
@@ -29,6 +29,7 @@ libraryDependencies ++= Seq(
   gtSparkTestKit,
   logging,
   scalatest,
+  apacheCommonsEmail,
 
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.340" % Provided
 )

--- a/src/project/Dependencies.scala
+++ b/src/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   val scalactic      = "org.scalactic"               %% "scalactic"                   % Version.scalactic
   val scalatest      = "org.scalatest"               %%  "scalatest"                  % Version.scalatest % "test"
   val jaiCore        = "javax.media" % "jai_core" % "1.1.3" % "test" from "http://download.osgeo.org/webdav/geotools/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar"
+  val apacheCommonsEmail = "org.apache.commons" % "commons-email" % Version.apacheCommonsEmail
   val hbaseCommon    = "org.apache.hbase" % "hbase-common" % "1.3.1"
   val hbaseClient    = "org.apache.hbase" % "hbase-client" % "1.3.1"
   val hbaseServer    = "org.apache.hbase" % "hbase-server" % "1.3.1"

--- a/src/project/Version.scala
+++ b/src/project/Version.scala
@@ -15,4 +15,5 @@ object Version {
   val scalaLogging = "3.5.0"
   val commonsIO = "2.5"
   val osmosis = "0.46"
+  val apacheCommonsEmail = "1.5"
 }


### PR DESCRIPTION
# Overview

This PR uses [Apache Commons Email](http://commons.apache.org/proper/commons-email/) to send plain text emails to an unauthenticated SMTP endpoint as long as the environment variable `AOI_FROM_ADDRESS` is set and not empty. Otherwise, the CLI continues to default to publishing email messages to stdout.

## Demo

I configured my environment with:
```
export AOI_FROM_ADDRESS=noreply@foo.com
export AOI_SMTP_HOSTNAME=localhost
export AOI_SMTP_PORT=1025
```
and started a [MailHog](https://github.com/mailhog/MailHog) container with:
```
docker run -p 8025:8025 -p 1025:1025 mailhog/mailhog
```
Then I ran the CLI from SBT after configuring some Notification objects in the connected Postgres database, something like:
```
./sbt
project analytics
 test:runMain osmesa.analytics.oneoffs.StreamingAOIMonitor --augmented-diff-source s3://bucket/path/to/augmented-diffs/ --interval d --start-sequence 3769420
```
SBT stdout looks like:
![Screen Shot 2019-11-19 at 5 46 18 PM](https://user-images.githubusercontent.com/1818302/69193692-58b8e900-0af5-11ea-9572-217e2e2945c4.png)

And we can verify that emails were properly sent via SMTP to the running mailhog endpoint by inspecting the web console provided by mailhog at http://localhost:8025 :
![Screen Shot 2019-11-19 at 5 46 13 PM](https://user-images.githubusercontent.com/1818302/69193716-68d0c880-0af5-11ea-8deb-5bf1d7e673d3.png)

Success!
