### PR TITLE
Fix total edit count reporting in ChangesetStatsForeachWriter

### DIFF
--- a/deployment/streaming/Makefile
+++ b/deployment/streaming/Makefile
@@ -103,4 +103,4 @@ batch-generate-edit-histograms:
 	./scripts/batch-generate-edit-histograms.sh
 
 batch-generate-db-backfill:
-	./scripts/batch-process.sh "OSMesa Batch Process" "ChangesetStatsCreator" 64 "[\"spark-submit\", \"--deploy-mode\", \"cluster\", \"--class\", \"osmesa.apps.batch.ChangesetStatsCreator\", \"--conf\", \"spark.executor.memoryOverhead=2g\", \"--conf\", \"spark.sql.shuffle.partitions=2000\", \"--conf\", \"spark.speculation=true\", \"${OSMESA_APPS_JAR}\", \"--history\", \"${HISTORY_ORC}\", \"--changesets\", \"${CHANGESETS_ORC}\", \"--changeset-stream\", \"${CHANGESET_SOURCE}\", \"--database-url\", \"${DB_URI}\"]"
+	./scripts/batch-process.sh "OSMesa Batch Process" "ChangesetStatsCreator" 64 "[\"spark-submit\", \"--deploy-mode\", \"cluster\", \"--class\", \"osmesa.apps.batch.ChangesetStatsCreator\", \"${OSMESA_APPS_JAR}\", \"--history\", \"${HISTORY_ORC}\", \"--changesets\", \"${CHANGESETS_ORC}\", \"--changeset-stream\", \"${CHANGESET_SOURCE}\", \"--database-url\", \"${DB_URI}\"]"

--- a/deployment/streaming/Makefile
+++ b/deployment/streaming/Makefile
@@ -103,4 +103,6 @@ batch-generate-edit-histograms:
 	./scripts/batch-generate-edit-histograms.sh
 
 batch-generate-db-backfill:
-	./scripts/batch-process.sh "OSMesa Batch Process" "ChangesetStatsCreator" 64 "[\"spark-submit\", \"--deploy-mode\", \"cluster\", \"--class\", \"osmesa.apps.batch.ChangesetStatsCreator\", \"${OSMESA_APPS_JAR}\", \"--history\", \"${HISTORY_ORC}\", \"--changesets\", \"${CHANGESETS_ORC}\", \"--changeset-stream\", \"${CHANGESET_SOURCE}\", \"--database-url\", \"${DB_URI}\"]"
+	BATCH_CORE_INSTANCE_TYPE=r5.xlarge BATCH_MASTER_INSTANCE_TYPE=m4.xlarge ./scripts/batch-process.sh \
+	  "OSMesa Batch Process" "ChangesetStatsCreator" 64 \
+		"[\"spark-submit\", \"--deploy-mode\", \"cluster\", \"--class\", \"osmesa.apps.batch.ChangesetStatsCreator\", \"${OSMESA_APPS_JAR}\", \"--history\", \"${HISTORY_ORC}\", \"--changesets\", \"${CHANGESETS_ORC}\", \"--changeset-stream\", \"${CHANGESET_SOURCE}\", \"--database-url\", \"${DB_URI}\"]"

--- a/deployment/streaming/config-deployment.mk.template
+++ b/deployment/streaming/config-deployment.mk.template
@@ -32,7 +32,8 @@ export SERVICE_ACCESS_SECURITY_GROUP := ${ECS_SECURITY_GROUP}
 export EMR_MASTER_SECURITY_GROUP :=
 export EMR_SLAVE_SECURITY_GROUP :=
 
-export BATCH_INSTANCE_TYPE := m4.xlarge
+export BATCH_CORE_INSTANCE_TYPE := m4.xlarge
+export BATCH_MASTER_INSTANCE_TYPE := m4.xlarge
 export OSMESA_APPS_JAR := s3://<bucket>/osmesa-apps.jar
 
 export HISTORY_ORC :=

--- a/deployment/streaming/scripts/batch-generate-edit-histograms.sh
+++ b/deployment/streaming/scripts/batch-generate-edit-histograms.sh
@@ -24,13 +24,13 @@ aws emr create-cluster \
 	        "InstanceCount": 1,
 	        "BidPrice": "OnDemandPrice",
 	        "InstanceGroupType": "MASTER",
-	        "InstanceType": "${BATCH_INSTANCE_TYPE}",
+	        "InstanceType": "${BATCH_MASTER_INSTANCE_TYPE}",
 	        "Name":"Master"
 	      }, {
 	        "InstanceCount": 20,
 	        "BidPrice": "OnDemandPrice",
 	        "InstanceGroupType": "CORE",
-	        "InstanceType": "${BATCH_INSTANCE_TYPE}",
+	        "InstanceType": "${BATCH_CORE_INSTANCE_TYPE}",
 	        "Name":"Workers"
 	      }
 	    ]' \

--- a/deployment/streaming/scripts/batch-generate-footprints.sh
+++ b/deployment/streaming/scripts/batch-generate-footprints.sh
@@ -24,13 +24,13 @@ aws emr create-cluster \
 	        "InstanceCount": 1,
 	        "BidPrice": "OnDemandPrice",
 	        "InstanceGroupType": "MASTER",
-	        "InstanceType": "${BATCH_INSTANCE_TYPE}",
+	        "InstanceType": "${BATCH_MASTER_INSTANCE_TYPE}",
 	        "Name":"Master"
 	      }, {
 	        "InstanceCount": 20,
 	        "BidPrice": "OnDemandPrice",
 	        "InstanceGroupType": "CORE",
-	        "InstanceType": "${BATCH_INSTANCE_TYPE}",
+	        "InstanceType": "${BATCH_CORE_INSTANCE_TYPE}",
 	        "Name":"Workers"
 	      }
 	    ]' \

--- a/deployment/streaming/scripts/batch-process.sh
+++ b/deployment/streaming/scripts/batch-process.sh
@@ -34,7 +34,7 @@ aws emr create-cluster \
 	        \"InstanceCount\": 1,
 	        \"BidPrice\": \"OnDemandPrice\",
 	        \"InstanceGroupType\": \"MASTER\",
-	        \"InstanceType\": \"m4.xlarge\",
+	        \"InstanceType\": \"${BATCH_MASTER_INSTANCE_TYPE}\",
 	        \"Name\":\"Master\",
 	        \"EbsConfiguration\": {
 						\"EbsOptimized\": true,
@@ -49,7 +49,7 @@ aws emr create-cluster \
 	        \"InstanceCount\": ${NUM_EXECUTORS},
 	        \"BidPrice\": \"OnDemandPrice\",
 	        \"InstanceGroupType\": \"CORE\",
-	        \"InstanceType\": \"r5.xlarge\",
+	        \"InstanceType\": \"${BATCH_CORE_INSTANCE_TYPE}\",
 	        \"Name\":\"Workers\",
 	        \"EbsConfiguration\": {
 						\"EbsOptimized\": true,

--- a/deployment/streaming/scripts/batch-process.sh
+++ b/deployment/streaming/scripts/batch-process.sh
@@ -14,6 +14,7 @@ set -x
 aws emr create-cluster \
     --applications Name=Ganglia Name=Spark \
     --log-uri ${S3_LOG_URI} \
+		--configurations "file://scripts/emr-configurations/batch-process.json" \
     --ebs-root-volume-size 10 \
     --ec2-attributes "{
 	      \"KeyName\": \"${KEYPAIR}\",
@@ -22,8 +23,8 @@ aws emr create-cluster \
 	      \"EmrManagedMasterSecurityGroup\": \"${MASTER_SECURITY_GROUP}\",
 	      \"EmrManagedSlaveSecurityGroup\": \"${WORKER_SECURITY_GROUP}\",
 	      \"ServiceAccessSecurityGroup\": \"${SERVICE_ACCESS_SG}\",
-              \"AdditionalMasterSecurityGroups\": [\"${SANDBOX_SG}\"],
-              \"AdditionalSlaveSecurityGroups\": [\"${SANDBOX_SG}\"]
+        \"AdditionalMasterSecurityGroups\": [\"${SANDBOX_SG}\"],
+        \"AdditionalSlaveSecurityGroups\": [\"${SANDBOX_SG}\"]
 	    }" \
     --service-role EMR_DefaultRole \
     --release-label emr-5.19.0 \
@@ -33,18 +34,36 @@ aws emr create-cluster \
 	        \"InstanceCount\": 1,
 	        \"BidPrice\": \"OnDemandPrice\",
 	        \"InstanceGroupType\": \"MASTER\",
-	        \"InstanceType\": \"${BATCH_INSTANCE_TYPE}\",
-	        \"Name\":\"Master\"
+	        \"InstanceType\": \"m4.xlarge\",
+	        \"Name\":\"Master\",
+	        \"EbsConfiguration\": {
+						\"EbsOptimized\": true,
+						\"EbsBlockDeviceConfigs\": [{
+							\"VolumeSpecification\": {
+								\"VolumeType\": \"gp2\",
+								\"SizeInGB\": 1024
+							}
+						}]
+					}
 	      }, {
 	        \"InstanceCount\": ${NUM_EXECUTORS},
 	        \"BidPrice\": \"OnDemandPrice\",
 	        \"InstanceGroupType\": \"CORE\",
-	        \"InstanceType\": \"${BATCH_INSTANCE_TYPE}\",
-	        \"Name\":\"Workers\"
+	        \"InstanceType\": \"r5.xlarge\",
+	        \"Name\":\"Workers\",
+	        \"EbsConfiguration\": {
+						\"EbsOptimized\": true,
+						\"EbsBlockDeviceConfigs\": [{
+							\"VolumeSpecification\": {
+								\"VolumeType\": \"gp2\",
+								\"SizeInGB\": 1024
+							}
+						}]
+					}
 	      }
 	    ]" \
     --scale-down-behavior TERMINATE_AT_TASK_COMPLETION \
-    --auto-terminate \
+		--auto-terminate \
     --region us-east-1 \
     --steps "[
 	      {

--- a/deployment/streaming/scripts/batch-process.sh
+++ b/deployment/streaming/scripts/batch-process.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ -z ${VERSION_TAG+x} ]; then
-    echo "Do not run this script directly.  Use the Makefile in the parent directory."
-    exit 1
+  echo "Do not run this script directly.  Use the Makefile in the parent directory."
+  exit 1
 fi
 
 CLUSTER_NAME=$1
@@ -12,66 +12,66 @@ ARGS=$4
 
 set -x
 aws emr create-cluster \
-    --applications Name=Ganglia Name=Spark \
-    --log-uri ${S3_LOG_URI} \
-		--configurations "file://scripts/emr-configurations/batch-process.json" \
-    --ebs-root-volume-size 10 \
-    --ec2-attributes "{
-	      \"KeyName\": \"${KEYPAIR}\",
-	      \"InstanceProfile\":\"EMR_EC2_DefaultRole\",
-	      \"SubnetId\": \"${SUBNET}\",
-	      \"EmrManagedMasterSecurityGroup\": \"${MASTER_SECURITY_GROUP}\",
-	      \"EmrManagedSlaveSecurityGroup\": \"${WORKER_SECURITY_GROUP}\",
-	      \"ServiceAccessSecurityGroup\": \"${SERVICE_ACCESS_SG}\",
-        \"AdditionalMasterSecurityGroups\": [\"${SANDBOX_SG}\"],
-        \"AdditionalSlaveSecurityGroups\": [\"${SANDBOX_SG}\"]
-	    }" \
-    --service-role EMR_DefaultRole \
-    --release-label emr-5.19.0 \
-    --name "$CLUSTER_NAME" \
-    --instance-groups "[
-	      {
-	        \"InstanceCount\": 1,
-	        \"BidPrice\": \"OnDemandPrice\",
-	        \"InstanceGroupType\": \"MASTER\",
-	        \"InstanceType\": \"${BATCH_MASTER_INSTANCE_TYPE}\",
-	        \"Name\":\"Master\",
-	        \"EbsConfiguration\": {
-						\"EbsOptimized\": true,
-						\"EbsBlockDeviceConfigs\": [{
-							\"VolumeSpecification\": {
-								\"VolumeType\": \"gp2\",
-								\"SizeInGB\": 1024
-							}
-						}]
-					}
-	      }, {
-	        \"InstanceCount\": ${NUM_EXECUTORS},
-	        \"BidPrice\": \"OnDemandPrice\",
-	        \"InstanceGroupType\": \"CORE\",
-	        \"InstanceType\": \"${BATCH_CORE_INSTANCE_TYPE}\",
-	        \"Name\":\"Workers\",
-	        \"EbsConfiguration\": {
-						\"EbsOptimized\": true,
-						\"EbsBlockDeviceConfigs\": [{
-							\"VolumeSpecification\": {
-								\"VolumeType\": \"gp2\",
-								\"SizeInGB\": 1024
-							}
-						}]
-					}
-	      }
-	    ]" \
-    --scale-down-behavior TERMINATE_AT_TASK_COMPLETION \
-		--auto-terminate \
-    --region us-east-1 \
-    --steps "[
-	      {
-	        \"Args\": $ARGS,
-	        \"Type\": \"CUSTOM_JAR\",
-	        \"ActionOnFailure\": \"TERMINATE_CLUSTER\",
-	        \"Jar\": \"command-runner.jar\",
-	        \"Properties\": \"\",
-	        \"Name\": \"$STEP_NAME\"
-	      }
-	    ]"
+  --applications Name=Ganglia Name=Spark \
+  --log-uri ${S3_LOG_URI} \
+  --configurations "file://scripts/emr-configurations/batch-process.json" \
+  --ebs-root-volume-size 10 \
+  --ec2-attributes "{
+      \"KeyName\": \"${KEYPAIR}\",
+      \"InstanceProfile\":\"EMR_EC2_DefaultRole\",
+      \"SubnetId\": \"${SUBNET}\",
+      \"EmrManagedMasterSecurityGroup\": \"${MASTER_SECURITY_GROUP}\",
+      \"EmrManagedSlaveSecurityGroup\": \"${WORKER_SECURITY_GROUP}\",
+      \"ServiceAccessSecurityGroup\": \"${SERVICE_ACCESS_SG}\",
+      \"AdditionalMasterSecurityGroups\": [\"${SANDBOX_SG}\"],
+      \"AdditionalSlaveSecurityGroups\": [\"${SANDBOX_SG}\"]
+    }" \
+  --service-role EMR_DefaultRole \
+  --release-label emr-5.19.0 \
+  --name "$CLUSTER_NAME" \
+  --instance-groups "[
+      {
+        \"InstanceCount\": 1,
+        \"BidPrice\": \"OnDemandPrice\",
+        \"InstanceGroupType\": \"MASTER\",
+        \"InstanceType\": \"${BATCH_MASTER_INSTANCE_TYPE}\",
+        \"Name\":\"Master\",
+        \"EbsConfiguration\": {
+          \"EbsOptimized\": true,
+          \"EbsBlockDeviceConfigs\": [{
+            \"VolumeSpecification\": {
+              \"VolumeType\": \"gp2\",
+              \"SizeInGB\": 1024
+            }
+          }]
+        }
+      }, {
+        \"InstanceCount\": ${NUM_EXECUTORS},
+        \"BidPrice\": \"OnDemandPrice\",
+        \"InstanceGroupType\": \"CORE\",
+        \"InstanceType\": \"${BATCH_CORE_INSTANCE_TYPE}\",
+        \"Name\":\"Workers\",
+        \"EbsConfiguration\": {
+          \"EbsOptimized\": true,
+          \"EbsBlockDeviceConfigs\": [{
+            \"VolumeSpecification\": {
+              \"VolumeType\": \"gp2\",
+              \"SizeInGB\": 1024
+            }
+          }]
+        }
+      }
+    ]" \
+  --scale-down-behavior TERMINATE_AT_TASK_COMPLETION \
+  --auto-terminate \
+  --region us-east-1 \
+  --steps "[
+      {
+        \"Args\": $ARGS,
+        \"Type\": \"CUSTOM_JAR\",
+        \"ActionOnFailure\": \"TERMINATE_CLUSTER\",
+        \"Jar\": \"command-runner.jar\",
+        \"Properties\": \"\",
+        \"Name\": \"$STEP_NAME\"
+      }
+    ]"

--- a/deployment/streaming/scripts/emr-configurations/batch-process.json
+++ b/deployment/streaming/scripts/emr-configurations/batch-process.json
@@ -1,0 +1,93 @@
+[
+  {
+    "Classification": "spark",
+    "Properties": {
+      "maximizeResourceAllocation": "false"
+    }
+  },
+  {
+    "Classification": "spark-defaults",
+    "Properties": {
+        "spark.driver.maxResultSize": "3G",
+        "spark.dynamicAllocation.enabled": "true",
+        "spark.shuffle.service.enabled": "true",
+        "spark.shuffle.compress": "true",
+        "spark.shuffle.spill.compress": "true",
+        "spark.sql.shuffle.partitions": "2000",
+        "spark.speculation": "true",
+        "spark.rdd.compress": "true",
+        "spark.executor.memory": "2G",
+        "spark.executor.memoryOverhead": "1G",
+        "spark.driver.cores": "2",
+        "spark.driver.memory": "10G",
+        "spark.driver.memoryOverhead": "1G",
+        "spark.driver.maxResultSize": "3G",
+        "spark.executor.extraJavaOptions" : "-XX:+UseParallelGC -Dgeotrellis.s3.threads.rdd.write=64"
+    }
+  },
+  {
+    "Classification": "hdfs-site",
+    "Properties": {
+      "dfs.replication": "1",
+      "dfs.permissions": "false",
+      "dfs.datanode.max.xcievers": "16384",
+      "dfs.datanode.max.transfer.threads": "16384",
+      "dfs.datanode.balance.max.concurrent.moves": "1000",
+      "dfs.datanode.balance.bandwidthPerSec": "100000000"
+    }
+  },
+  {
+    "Classification": "yarn-site",
+    "Properties": {
+      "yarn.resourcemanager.am.max-attempts": "1",
+      "yarn.nodemanager.vmem-check-enabled": "false",
+      "yarn.nodemanager.pmem-check-enabled": "false"
+    }
+  },
+  {
+    "Classification": "hadoop-env",
+    "Configurations": [
+      {
+        "Classification": "export",
+        "Properties": {
+          "JAVA_HOME": "/usr/lib/jvm/java-1.8.0",
+          "GDAL_DATA": "/usr/local/share/gdal",
+          "LD_LIBRARY_PATH": "/usr/local/lib",
+          "PYSPARK_PYTHON": "python27",
+          "PYSPARK_DRIVER_PYTHON": "python27"
+        }
+      }
+    ]
+  },
+  {
+    "Classification": "spark-env",
+    "Configurations": [
+      {
+        "Classification": "export",
+        "Properties": {
+          "JAVA_HOME": "/usr/lib/jvm/java-1.8.0",
+          "GDAL_DATA": "/usr/local/share/gdal",
+          "LD_LIBRARY_PATH": "/usr/local/lib",
+          "SPARK_PRINT_LAUNCH_COMMAND": "1",
+          "PYSPARK_PYTHON": "python27",
+          "PYSPARK_DRIVER_PYTHON": "python27"
+        }
+      }
+    ]
+  },
+  {
+    "Classification": "yarn-env",
+    "Configurations": [
+      {
+        "Classification": "export",
+        "Properties": {
+          "JAVA_HOME": "/usr/lib/jvm/java-1.8.0",
+          "GDAL_DATA": "/usr/local/share/gdal",
+          "LD_LIBRARY_PATH": "/usr/local/lib",
+          "PYSPARK_PYTHON": "python27",
+          "PYSPARK_DRIVER_PYTHON": "python27"
+        }
+      }
+    ]
+  }
+]

--- a/deployment/streaming/scripts/emr-configurations/batch-process.json
+++ b/deployment/streaming/scripts/emr-configurations/batch-process.json
@@ -8,21 +8,20 @@
   {
     "Classification": "spark-defaults",
     "Properties": {
-        "spark.driver.maxResultSize": "3G",
-        "spark.dynamicAllocation.enabled": "true",
-        "spark.shuffle.service.enabled": "true",
-        "spark.shuffle.compress": "true",
-        "spark.shuffle.spill.compress": "true",
-        "spark.sql.shuffle.partitions": "2000",
-        "spark.speculation": "true",
-        "spark.rdd.compress": "true",
-        "spark.executor.memory": "2G",
-        "spark.executor.memoryOverhead": "1G",
-        "spark.driver.cores": "2",
-        "spark.driver.memory": "10G",
-        "spark.driver.memoryOverhead": "1G",
-        "spark.driver.maxResultSize": "3G",
-        "spark.executor.extraJavaOptions" : "-XX:+UseParallelGC -Dgeotrellis.s3.threads.rdd.write=64"
+      "spark.dynamicAllocation.enabled": "true",
+      "spark.shuffle.service.enabled": "true",
+      "spark.shuffle.compress": "true",
+      "spark.shuffle.spill.compress": "true",
+      "spark.sql.shuffle.partitions": "2000",
+      "spark.speculation": "true",
+      "spark.rdd.compress": "true",
+      "spark.executor.memory": "2G",
+      "spark.executor.memoryOverhead": "1G",
+      "spark.driver.cores": "2",
+      "spark.driver.memory": "10G",
+      "spark.driver.memoryOverhead": "1G",
+      "spark.driver.maxResultSize": "3G",
+      "spark.executor.extraJavaOptions" : "-XX:+UseParallelGC -Dgeotrellis.s3.threads.rdd.write=64"
     }
   },
   {

--- a/src/analytics/src/main/scala/osmesa/analytics/stats/ChangesetStatsForeachWriter.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/stats/ChangesetStatsForeachWriter.scala
@@ -64,7 +64,7 @@ class ChangesetStatsForeachWriter(databaseUri: URI,
       |      GROUP BY key
       |    ) AS _
       |  ),
-      |  total_edits = c.total_edits + EXCLUDED.total_edits,
+      |  total_edits = coalesce(c.total_edits, 0) + coalesce(EXCLUDED.total_edits, 0),
       |  augmented_diffs = coalesce(c.augmented_diffs, ARRAY[]::integer[]) || EXCLUDED.augmented_diffs,
       |  updated_at = current_timestamp
       |WHERE c.id = EXCLUDED.id


### PR DESCRIPTION
This should fix total_edits ending up null as
soon as one of the operands is null for any
given row write operation.

## Notes

Both coalesces are required as a new changeset could have no interesting counts, same as the old summed changesets.

I updated the batch-process.sh script to use a json configuration for its spark conf. This should make it easier to adjust in the future. I also swapped to static instance types and EBS configuration since we need a particular combination of CPU/Mem/Disk resources for this job to run successfully.

There remain count discrepancies between the production and staging databases. I opened a separate epic to continue to investigate this (#186), as those incorrect values are outside the scope of this specific fix.

## Testing

To verify this fix, I compared the total_edits in user_statistics with the counts currently on production. While they remain low compared to production, they are much closer than they were before. In addition, I ran a query to determine if there are any changesets that have values in the jsonb `counts` field but where `total_edits` remains null. There are none:
```
osmesa_stats_staging=> select count(*) from changesets where total_edits is null and counts is not null;
 count 
-------
     0
(1 row)
```
