### PR TITLE
Add/fix some utilities for managing changeset orcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ deployment/terraform/terraform.tfvars
 *.tfstate.backup
 .terraform
 
+# Makefile configs
+*.mk
+
 # Ansible
 deployment/ansible/roles/azavea.*
 
@@ -82,4 +85,3 @@ dist/
 # Temporary credentials
 emr/terraform/auth.json
 
-derby.log

--- a/deployment/batch/makefiles/Makefile
+++ b/deployment/batch/makefiles/Makefile
@@ -53,6 +53,28 @@ create-cluster:
 'Name=Workers,${WORKER_BID_PRICE}InstanceCount=${WORKER_COUNT},InstanceGroupType=CORE,InstanceType=${WORKER_INSTANCE}${EMR_ATTRS_CORE}' \
 | tee cluster-id.txt
 
+update-changeset-orc:
+	aws emr add-steps --output text --cluster-id ${CLUSTER_ID} \
+--steps Type=CUSTOM_JAR,Name="Changeset ORC Update",Jar=command-runner.jar,Args=[\
+spark-submit,--master,yarn,--deploy-mode,cluster,\
+--class,osmesa.apps.batch.MergeChangesets,\
+--driver-memory,${DRIVER_MEMORY},\
+--driver-cores,${DRIVER_CORES},\
+--executor-memory,${EXECUTOR_MEMORY},\
+--executor-cores,${EXECUTOR_CORES},\
+--conf,spark.driver.maxResultSize=3g,\
+--conf,spark.dynamicAllocation.enabled=true,\
+--conf,spark.yarn.executor.memoryOverhead=${YARN_OVERHEAD},\
+--conf,spark.yarn.driver.memoryOverhead=${YARN_OVERHEAD},\
+--conf,spark.shuffle.io.numConnectionsPerPeer=4,\
+--conf,spark.shuffle.io.connectionTimeout=18000s,\
+--conf,spark.shuffle.service.enabled=true,\
+${S3_URI}/${APPS_JAR},\
+--changesets=${CHANGESET_URI},\
+${CHANGESET_ORC_SOURCE},\
+${CHANGESET_ORC_DEST}\
+] | cut -f2 | tee last-step-id.txt
+
 upload-apps: ${APPS_ASSEMBLY}
 	@aws s3 cp ${APPS_ASSEMBLY} ${S3_URI}/
 

--- a/deployment/batch/makefiles/config-run.mk.template
+++ b/deployment/batch/makefiles/config-run.mk.template
@@ -8,4 +8,7 @@ export OUTPUT_LOCATION := [TARGET_BUCKET]
 
 export ORC_CACHE_LOCATION := ${S3_URI}/cache
 export VECTORTILE_CATALOG_LOCATION = ${S3_URI}/vectortiles
+
 export CHANGESET_URI := [REPLICATION URL]
+export CHANGESET_ORC_SOURCE := [S3 URI of existing orc]
+export CHANGESET_ORC_DEST := [S3 URI of new orc]

--- a/src/apps/src/main/scala/osmesa/apps/batch/MergeChangesets.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/MergeChangesets.scala
@@ -81,7 +81,7 @@ object MergeChangesets
         import spark.implicits._
 
         val df = spark.read.orc(orcUri.toString)
-        val lastModified = df.select(max(coalesce('closed_at, 'created_at))).first.getAs[Timestamp](0)
+        val lastModified = df.select(max(coalesce('closedAt, 'createdAt))).first.getAs[Timestamp](0)
 
         val startSequence = findSequenceFor(lastModified.toInstant, changesetSource)
         val endSequence = endTime.map(findSequenceFor(_, changesetSource)).getOrElse(getCurrentSequence(changesetSource).get.sequence)

--- a/src/apps/src/main/scala/osmesa/apps/batch/MergeChangesets.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/MergeChangesets.scala
@@ -101,15 +101,15 @@ object MergeChangesets
           .union(df.select(
             'id,
             'tags,
-            'created_at as 'createdAt,
+            'createdAt,
             'open,
-            'closed_at as 'closedAt,
-            'comments_count as 'commentsCount,
-            'min_lat as 'minLat,
-            'max_lat as 'maxLat,
-            'min_lon as 'minLon,
-            'max_lon as 'maxLon,
-            'num_changes as 'numChanges,
+            'closedAt,
+            'commentsCount,
+            'minLat,
+            'maxLat,
+            'minLon,
+            'maxLon,
+            'numChanges,
             'uid,
             'user)
           )


### PR DESCRIPTION
During bulk ingests, we need to update the changeset orc files from the changeset stream.  There were some problems to fix with this process, and it's useful to add some automatic tools to the Makefile to assist in the process.