### PR TITLE
Add measurements + counts for landuse and natural tags

### DIFF
--- a/src/analytics/src/main/scala/osmesa/analytics/stats/package.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/stats/package.scala
@@ -9,14 +9,27 @@ import vectorpipe.functions.osm._
 import org.locationtech.geomesa.spark.jts._
 
 package object stats {
-  def addDelta(df: DataFrame): DataFrame = {
+  def addLinearDelta(df: DataFrame): DataFrame = {
     import df.sparkSession.implicits._
 
-    df.withColumn("delta",
+    df.withColumn("linearDelta",
       when(isLinear('tags),
         abs(
           coalesce(when(st_geometryType('geom) === "LineString", st_lengthSphere(st_castToLineString('geom))), lit(0)) -
             coalesce(when(st_geometryType('prevGeom) === "LineString", st_lengthSphere(st_castToLineString('prevGeom))), lit(0))
+        ))
+        .otherwise(lit(0)))
+  }
+
+  def addAreaDelta(df: DataFrame): DataFrame = {
+    import df.sparkSession.implicits._
+
+    df.withColumn("areaDelta",
+      when(isArea('tags),
+        abs(
+          coalesce(when(st_geometryType('geom) === "Polygon", st_area(st_castToPolygon('geom))), lit(0)) -
+            coalesce(when(st_geometryType('prevGeom) === "Polygon", st_area(st_castToPolygon('geom))), lit(0))
+
         ))
         .otherwise(lit(0)))
   }
@@ -30,7 +43,9 @@ package object stats {
   }
 
   implicit class DataFrameHelper(df: DataFrame) {
-    def withDelta: DataFrame = addDelta(df)
+    def withAreaDelta: DataFrame = addAreaDelta(df)
+
+    def withLinearDelta: DataFrame = addLinearDelta(df)
 
     def withPrevGeom: DataFrame = addPrevGeom(df)
   }
@@ -45,6 +60,12 @@ package object stats {
     isWaterway(tags) or
     isCoastline(tags) or
     isPOI(tags) as 'isInterestingWay
+
+  def isLanduse(tags: Column): Column =
+    tags.getItem("landuse").isNotNull as 'isLanduse
+
+  def isNatural(tags: Column): Column =
+    tags.getItem("natural").isNotNull as 'isNatural
 
   // Does this feature represent a rail-related site or area (not track)
   def isRailFeature(tags: Column): Column =
@@ -64,27 +85,34 @@ package object stats {
   def isOther(tags: Column): Column = isTagged(tags) and
     not(isRoad((tags))) and
     not(isWaterway(tags)) and
-    not(isCoastline(tags)) and
     not(isBuilding(tags)) and
     not(isRailway(tags)) and
+    not(isNatural(tags)) and
+    not(isLanduse(tags)) and
     not(isPOI(tags)) as 'isOther
 
   def DefaultMeasurements(implicit sparkSession: SparkSession): Column = {
     import sparkSession.implicits._
 
     simplify_measurements(map(
-      lit("road_km_added"), (isRoad('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'delta / 1000,
-      lit("road_km_modified"), (isRoad('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'delta / 1000,
-      lit("road_km_deleted"), (isRoad('tags) and !'visible).cast(IntegerType) * 'delta / 1000,
-      lit("waterway_km_added"), (isWaterway('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'delta / 1000,
-      lit("waterway_km_modified"), (isWaterway('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'delta / 1000,
-      lit("waterway_km_deleted"), (isWaterway('tags) and !'visible).cast(IntegerType) * 'delta / 1000,
-      lit("coastline_km_added"), (isCoastline('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'delta / 1000,
-      lit("coastline_km_modified"), (isCoastline('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'delta / 1000,
-      lit("coastline_km_deleted"), (isCoastline('tags) and !'visible).cast(IntegerType) * 'delta / 1000,
-      lit("railline_km_added"), (isRailLine('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'delta / 1000,
-      lit("railline_km_modified"), (isRailLine('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'delta / 1000,
-      lit("railline_km_deleted"), (isRailLine('tags) and !'visible).cast(IntegerType) * 'delta / 1000
+      lit("road_km_added"), (isRoad('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'linearDelta / 1000,
+      lit("road_km_modified"), (isRoad('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("road_km_deleted"), (isRoad('tags) and !'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("waterway_km_added"), (isWaterway('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'linearDelta / 1000,
+      lit("waterway_km_modified"), (isWaterway('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("waterway_km_deleted"), (isWaterway('tags) and !'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("coastline_km_added"), (isCoastline('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'linearDelta / 1000,
+      lit("coastline_km_modified"), (isCoastline('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("coastline_km_deleted"), (isCoastline('tags) and !'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("railline_km_added"), (isRailLine('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'linearDelta / 1000,
+      lit("railline_km_modified"), (isRailLine('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("railline_km_deleted"), (isRailLine('tags) and !'visible).cast(IntegerType) * 'linearDelta / 1000,
+      lit("landuse_km2_added"), (isLanduse('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'areaDelta / 1000,
+      lit("landuse_km2_modified"), (isLanduse('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'areaDelta / 1000,
+      lit("landuse_km2_deleted"), (isLanduse('tags) and !'visible).cast(IntegerType) * 'areaDelta / 1000,
+      lit("natural_km2_added"), (isNatural('tags) and isNew('version, 'minorVersion)).cast(IntegerType) * 'areaDelta / 1000,
+      lit("natural_km2_modified"), (isNatural('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType) * 'areaDelta / 1000,
+      lit("natural_km2_deleted"), (isNatural('tags) and !'visible).cast(IntegerType) * 'areaDelta / 1000
     )) as 'measurements
   }
 
@@ -113,6 +141,12 @@ package object stats {
       lit("pois_added"), (isPOI('tags) and isNew('version, 'minorVersion)).cast(IntegerType),
       lit("pois_modified"), (isPOI('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType),
       lit("pois_deleted"), (isPOI('tags) and !'visible).cast(IntegerType),
+      lit("landuse_added"), (isLanduse('tags) and isNew('version, 'minorVersion)).cast(IntegerType),
+      lit("landuse_modified"), (isLanduse('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType),
+      lit("landuse_deleted"), (isLanduse('tags) and !'visible).cast(IntegerType),
+      lit("natural_added"), (isNatural('tags) and isNew('version, 'minorVersion)).cast(IntegerType),
+      lit("natural_modified"), (isNatural('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType),
+      lit("natural_deleted"), (isNatural('tags) and !'visible).cast(IntegerType),
       lit("other_added"), (isOther('tags) and isNew('version, 'minorVersion)).cast(IntegerType),
       lit("other_modified"), (isOther('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType),
       lit("other_deleted"), (isOther('tags) and !'visible).cast(IntegerType)
@@ -126,6 +160,12 @@ package object stats {
       lit("pois_added"), (isPOI('tags) and 'version === 1).cast(IntegerType),
       lit("pois_modified"), (isPOI('tags) and 'version > 1 and 'visible).cast(IntegerType),
       lit("pois_deleted"), (isPOI('tags) and !'visible).cast(IntegerType),
+      lit("landuse_added"), (isLanduse('tags) and 'version === 1).cast(IntegerType),
+      lit("landuse_modified"), (isLanduse('tags) and 'version > 1 and 'visible).cast(IntegerType),
+      lit("landuse_deleted"), (isLanduse('tags) and !'visible).cast(IntegerType),
+      lit("natural_added"), (isNatural('tags) and 'version === 1).cast(IntegerType),
+      lit("natural_modified"), (isNatural('tags) and 'version > 1 and 'visible).cast(IntegerType),
+      lit("natural_deleted"), (isNatural('tags) and !'visible).cast(IntegerType),
       lit("other_added"), (isOther('tags) and isNew('version, 'minorVersion)).cast(IntegerType),
       lit("other_modified"), (isOther('tags) and not(isNew('version, 'minorVersion)) and 'visible).cast(IntegerType),
       lit("other_deleted"), (isOther('tags) and !'visible).cast(IntegerType)

--- a/src/analytics/src/main/scala/osmesa/analytics/stats/package.scala
+++ b/src/analytics/src/main/scala/osmesa/analytics/stats/package.scala
@@ -9,6 +9,10 @@ import vectorpipe.functions.osm._
 import org.locationtech.geomesa.spark.jts._
 
 package object stats {
+
+  @deprecated()
+  def withDelta(df: DataFrame): DataFrame = addLinearDelta(df).withColumnRenamed("linearDelta", "delta")
+
   def addLinearDelta(df: DataFrame): DataFrame = {
     import df.sparkSession.implicits._
 

--- a/src/apps/src/main/scala/osmesa/apps/batch/ChangesetStatsCreator.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/ChangesetStatsCreator.scala
@@ -84,7 +84,7 @@ object ChangesetStatsCreator
                 )
                 .drop('geometryChanged))
 
-            val augmentedWays = wayGeoms.withPrevGeom.withDelta
+            val augmentedWays = wayGeoms.withPrevGeom.withLinearDelta.withAreaDelta
 
             val wayChangesetStats = augmentedWays
               .select(

--- a/src/apps/src/main/scala/osmesa/apps/streaming/ChangesetStatsUpdater.scala
+++ b/src/apps/src/main/scala/osmesa/apps/streaming/ChangesetStatsUpdater.scala
@@ -106,7 +106,8 @@ object ChangesetStatsUpdater
             val geoms = ss.read.format(Source.AugmentedDiffs).options(options).load
 
             Geocode(geoms.where(isTagged('tags)))
-              .withDelta
+              .withLinearDelta
+              .withAreaDelta
               .select(
                 'sequence,
                 'changeset,

--- a/src/apps/src/main/scala/osmesa/apps/streaming/StreamingChangesetStatsUpdater.scala
+++ b/src/apps/src/main/scala/osmesa/apps/streaming/StreamingChangesetStatsUpdater.scala
@@ -111,7 +111,8 @@ object StreamingChangesetStatsUpdater
                 // if sequences are received sequentially (and atomically), 0 seconds should suffice; anything received with an
                 // earlier timestamp after that point will be dropped
                 .withWatermark("timestamp", "0 seconds")
-                .withDelta
+                .withLinearDelta
+                .withAreaDelta
                 .select(
                   'timestamp,
                   'sequence,

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -27,8 +27,7 @@ lazy val commonSettings = Seq(
     "locationtech-releases" at "https://repo.locationtech.org/content/repositories/releases/",
     "locationtech-snapshots" at "https://repo.locationtech.org/content/repositories/snapshots/",
     "geosolutions" at "http://maven.geo-solutions.it/",
-    "boundless" at "https://repo.boundlessgeo.com/main/",
-    "osgeo" at "http://download.osgeo.org/webdav/geotools/",
+    "osgeo-releases" at "https://repo.osgeo.org/repository/release/",
     "apache.commons.io" at "https://mvnrepository.com/artifact/commons-io/commons-io"
   ),
   updateOptions := updateOptions.value.withGigahorse(false),


### PR DESCRIPTION
For measurements, only include landuse and natural objects
that are areas.

For counts, count everything.

I switched `withDelta` to `withLinearDelta` to clarify
that it only computes deltas for linear features. An
alternative implementation would be to have the
original `withDelta` method compute both area and linear
deltas, but then its unclear in the generated column
whether the number has length or area units.

VectorPipe uses an outdated set of area keys from
github.com/osmlab/id-area-keys. Counts _should_ be more
accurate if we update to the latest area keys list. @mojodna 
💯 points for the comment noting where the area keys map
came from including version! 
Here's the current diff:
osmlab/id-area-keys@f645eca#diff-f36fb8b1baaccf032007cfcc70836c1d