### PR TITLE
Add foreign keys and indices to postgresql schema.

### DIFF
--- a/deployment/sql/changesets.sql
+++ b/deployment/sql/changesets.sql
@@ -4,7 +4,9 @@ CREATE TABLE changesets (
     counts jsonb,
     total_edits integer,
     editor text,
-    user_id integer,
+    user_id integer
+        CONSTRAINT changesets_users_id_fk
+		REFERENCES users,
     created_at timestamp with time zone,
     closed_at timestamp with time zone,
     augmented_diffs integer[],
@@ -13,3 +15,13 @@ CREATE TABLE changesets (
 );
 
 CREATE INDEX changesets_user_id ON changesets(user_id);
+
+CREATE INDEX changesets_created_at_index
+    ON changesets (created_at);
+
+CREATE INDEX changesets_closed_at_index
+    ON changesets (closed_at);
+
+CREATE INDEX changesets_updated_at_index
+    ON changesets (updated_at);
+

--- a/deployment/sql/changesets.sql
+++ b/deployment/sql/changesets.sql
@@ -4,9 +4,7 @@ CREATE TABLE changesets (
     counts jsonb,
     total_edits integer,
     editor text,
-    user_id integer
-        CONSTRAINT changesets_users_id_fk
-		REFERENCES users,
+    user_id integer,
     created_at timestamp with time zone,
     closed_at timestamp with time zone,
     augmented_diffs integer[],

--- a/deployment/sql/changesets_countries.sql
+++ b/deployment/sql/changesets_countries.sql
@@ -1,7 +1,15 @@
 CREATE TABLE changesets_countries (
-    changeset_id integer NOT NULL,
-    country_id integer NOT NULL,
+    changeset_id integer NOT NULL
+        CONSTRAINT changesets_countries_changesets_id_fk
+		REFERENCES changesets,
+    country_id integer NOT NULL
+        CONSTRAINT changesets_countries_countries_id_fk
+		REFERENCES countries,
     edit_count integer NOT NULL,
     augmented_diffs integer[],
     PRIMARY KEY(changeset_id, country_id)
 );
+
+-- support joining on foreign keys (add index in reverse order of the primary key)
+CREATE INDEX changesets_countries_country_id_changeset_id_index
+	ON changesets_countries (country_id, changeset_id);

--- a/deployment/sql/changesets_hashtags.sql
+++ b/deployment/sql/changesets_hashtags.sql
@@ -1,5 +1,13 @@
 CREATE TABLE changesets_hashtags (
-    changeset_id integer NOT NULL,
-    hashtag_id integer NOT NULL,
+    changeset_id integer NOT NULL
+        CONSTRAINT changesets_hashtags_changesets_id_fk
+        REFERENCES changesets,
+    hashtag_id integer NOT NULL
+        CONSTRAINT changesets_hashtags_hashtags_id_fk
+        REFERENCES hashtags,
     PRIMARY KEY(changeset_id, hashtag_id)
 );
+
+-- support joining on foreign keys (add index in reverse order of the primary key)
+CREATE INDEX changesets_hashtags_hashtag_id_changeset_id_index
+    ON changesets_hashtags (hashtag_id, changeset_id);

--- a/deployment/sql/hashtags.sql
+++ b/deployment/sql/hashtags.sql
@@ -5,3 +5,7 @@ CREATE TABLE hashtags (
 );
 
 CREATE UNIQUE INDEX ON hashtags (hashtag);
+
+-- support for LIKE queries on hashtags
+CREATE EXTENSION pg_trgm;
+CREATE INDEX trgm_idx_hashtags ON hashtags USING gin (hashtag gin_trgm_ops);


### PR DESCRIPTION
This PR modifies the PG database schema.

- Makes foreign keys explicit.
- Adds indices to support joins with foreign keys, and to support queries we have seen in production.

### Known issues

- Some tables may contain so few records that the PG query planner will not actually  use the indices, but at least they will be in place for future.
- Adding the constraint `changesets_users_id_fk` into `changesets` is going to cause problems: Executing this on a development db, I got an error because some user_ids are not present in the user table:

```sql
alter table changesets
add constraint changesets_users_id_fk
foreign key (user_id) references users;
```

The missing users issue should be resolved before changing the table create statement here.

Please beware because I have not done any integration testing and do not really have any way to see what side effects it will cause.  😄

@CloudNiner I marked this as a Draft PR, because of the user_id concern.
