### PR TITLE
Do not count point stats differently during batch ingest

### DIFF
--- a/src/apps/src/main/scala/osmesa/apps/batch/ChangesetStatsCreator.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/ChangesetStatsCreator.scala
@@ -104,7 +104,7 @@ object ChangesetStatsCreator
               .select(
                 'changeset,
                 'countries,
-                pointCounts
+                DefaultCounts
               )
               .groupBy('changeset)
               .agg(


### PR DESCRIPTION
A bug was discovered where users had committed changes that were picked up by the streaming update, but lost after a bulk ingest.  These edits were valid, so there was understandable consternation.  

The problem is that we had a special `pointCounts` column function used only during bulk ingest that omitted a number of categories of edits from consideration if the underlying geometry was a point, including nodes tagged as buildings (which is [permissible](https://wiki.openstreetmap.org/wiki/Key:building)).  

This is a quick fix PR that seems to address the problem.  We ought to revisit this code, in case further streamlining is possible now that points/ways/relations are all being counted similarly.