### PR TITLE
Facilities for bulk ingest file prep

### DIFF
--- a/deployment/batch/makefiles/Makefile
+++ b/deployment/batch/makefiles/Makefile
@@ -47,11 +47,11 @@ create-cluster:
 --configurations "file://$(CURDIR)/scripts/configurations.json" \
 --log-uri ${S3_URI}/logs \
 --ec2-attributes KeyName=${EC2_KEY},SubnetId=${SUBNET_ID},EmrManagedMasterSecurityGroup=${MASTER_SECURITY_GROUP},EmrManagedSlaveSecurityGroup=${WORKER_SECURITY_GROUP},ServiceAccessSecurityGroup=${SERVICE_ACCESS_SG},AdditionalMasterSecurityGroups=${SANDBOX_SG},AdditionalSlaveSecurityGroups=${SANDBOX_SG} \
---applications Name=Ganglia Name=Hadoop Name=Hue Name=Spark Name=Zeppelin \
+--applications Name=Ganglia Name=Hadoop Name=Hue Name=Spark Name=Zeppelin Name=Hive \
 --instance-groups \
 'Name=Master,${MASTER_BID_PRICE}InstanceCount=1,InstanceGroupType=MASTER,InstanceType=${MASTER_INSTANCE}${EMR_ATTRS_MASTER}' \
 'Name=Workers,${WORKER_BID_PRICE}InstanceCount=${WORKER_COUNT},InstanceGroupType=CORE,InstanceType=${WORKER_INSTANCE}${EMR_ATTRS_CORE}' \
-| tee cluster-id.txt
+| cut -f2 | tee cluster-id.txt
 
 update-changeset-orc:
 	aws emr add-steps --output text --cluster-id ${CLUSTER_ID} \
@@ -77,6 +77,42 @@ ${CHANGESET_ORC_DEST}\
 
 upload-apps: ${APPS_ASSEMBLY}
 	@aws s3 cp ${APPS_ASSEMBLY} ${S3_URI}/
+
+prepare-bulk-ingest: upload-apps
+	@envsubst '$${PLANET_HISTORY_PBF} $${PLANET_HISTORY_ORC_DIR}' < scripts/latest-history-to-orc.sh > /tmp/latest-history-to-orc.sh
+	@aws s3 cp /tmp/latest-history-to-orc.sh ${S3_URI}/scripts/
+	aws emr create-cluster --name "${NAME}" ${COLOR_TAG} \
+--release-label emr-5.28.0 \
+--auto-terminate \
+--step-concurrency-level 10 \
+--output text \
+--use-default-roles \
+--configurations "file://$(CURDIR)/scripts/configurations.json" \
+--log-uri ${S3_URI}/logs \
+--ec2-attributes KeyName=${EC2_KEY},SubnetId=${SUBNET_ID},EmrManagedMasterSecurityGroup=${MASTER_SECURITY_GROUP},EmrManagedSlaveSecurityGroup=${WORKER_SECURITY_GROUP},ServiceAccessSecurityGroup=${SERVICE_ACCESS_SG},AdditionalMasterSecurityGroups=${SANDBOX_SG},AdditionalSlaveSecurityGroups=${SANDBOX_SG} \
+--applications Name=Ganglia Name=Hadoop Name=Hue Name=Spark Name=Zeppelin \
+--instance-groups \
+'Name=Master,${MASTER_BID_PRICE}InstanceCount=1,InstanceGroupType=MASTER,InstanceType=${MASTER_INSTANCE}${EMR_ATTRS_MASTER}' \
+'Name=Workers,${WORKER_BID_PRICE}InstanceCount=1,InstanceGroupType=CORE,InstanceType=${WORKER_INSTANCE}${EMR_ATTRS_CORE}' \
+--steps Type=CUSTOM_JAR,ActionOnFailure=CONTINUE,Name="History PBF to ORC",Jar=s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar,Args=["${S3_URI}/scripts/latest-history-to-orc.sh"] Type=CUSTOM_JAR,Name="Changeset ORC Update",Jar=command-runner.jar,Args=[\
+spark-submit,--master,yarn,--deploy-mode,cluster,\
+--class,osmesa.apps.batch.MergeChangesets,\
+--driver-memory,${DRIVER_MEMORY},\
+--driver-cores,${DRIVER_CORES},\
+--executor-memory,${EXECUTOR_MEMORY},\
+--executor-cores,${EXECUTOR_CORES},\
+--conf,spark.driver.maxResultSize=3g,\
+--conf,spark.dynamicAllocation.enabled=true,\
+--conf,spark.yarn.executor.memoryOverhead=${YARN_OVERHEAD},\
+--conf,spark.yarn.driver.memoryOverhead=${YARN_OVERHEAD},\
+--conf,spark.shuffle.io.numConnectionsPerPeer=4,\
+--conf,spark.shuffle.io.connectionTimeout=18000s,\
+--conf,spark.shuffle.service.enabled=true,\
+${S3_URI}/${APPS_JAR},\
+--changesets=${CHANGESET_URI},\
+${CHANGESET_ORC_SOURCE},\
+${CHANGESET_ORC_DEST}\
+]  | cut -f2 | tee cluster-id.txt
 
 ssh:
 	@aws emr ssh --cluster-id $(CLUSTER_ID) --key-pair-file "${PEM_FILE}"

--- a/deployment/batch/makefiles/Makefile
+++ b/deployment/batch/makefiles/Makefile
@@ -90,7 +90,7 @@ prepare-bulk-ingest: upload-apps
 --configurations "file://$(CURDIR)/scripts/configurations.json" \
 --log-uri ${S3_URI}/logs \
 --ec2-attributes KeyName=${EC2_KEY},SubnetId=${SUBNET_ID},EmrManagedMasterSecurityGroup=${MASTER_SECURITY_GROUP},EmrManagedSlaveSecurityGroup=${WORKER_SECURITY_GROUP},ServiceAccessSecurityGroup=${SERVICE_ACCESS_SG},AdditionalMasterSecurityGroups=${SANDBOX_SG},AdditionalSlaveSecurityGroups=${SANDBOX_SG} \
---applications Name=Ganglia Name=Hadoop Name=Hue Name=Spark Name=Zeppelin \
+--applications Name=Ganglia Name=Hadoop Name=Hue Name=Spark Name=Zeppelin Name=Hive \
 --instance-groups \
 'Name=Master,${MASTER_BID_PRICE}InstanceCount=1,InstanceGroupType=MASTER,InstanceType=${MASTER_INSTANCE}${EMR_ATTRS_MASTER}' \
 'Name=Workers,${WORKER_BID_PRICE}InstanceCount=1,InstanceGroupType=CORE,InstanceType=${WORKER_INSTANCE}${EMR_ATTRS_CORE}' \

--- a/deployment/batch/makefiles/config-run.mk.template
+++ b/deployment/batch/makefiles/config-run.mk.template
@@ -12,3 +12,6 @@ export VECTORTILE_CATALOG_LOCATION = ${S3_URI}/vectortiles
 export CHANGESET_URI := [REPLICATION URL]
 export CHANGESET_ORC_SOURCE := [S3 URI of existing orc]
 export CHANGESET_ORC_DEST := [S3 URI of new orc]
+
+export PLANET_HISTORY_PBF := [S3 URI of target planet history PBF]
+export PLANET_HISTORY_ORC_DIR := [S3 URI of converted planet history ORCs]

--- a/deployment/batch/makefiles/scripts/latest-history-to-orc.sh
+++ b/deployment/batch/makefiles/scripts/latest-history-to-orc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Install/build osm2orc
+cd /mnt
+sudo yum install -y git
+git clone https://github.com/mojodna/osm2orc.git
+cd osm2orc
+./gradlew distTar
+tar xf build/distributions/osm2orc-*.tar -C /tmp
+
+# Download latest planet history file
+aws s3 cp $PLANET_HISTORY_PBF /mnt
+
+# Convert to ORC
+DATE=$(stat /mnt/planet-history.osm.pbf | sed -n -e 's/-//g;s/Modify: \([0-9\-]*\).*/\1/p')
+/tmp/osm2orc-*/bin/osm2orc /mnt/planet-history.osm.pbf /mnt/planet-${DATE}.osh.orc
+
+# Upload ORC
+aws s3 cp /mnt/planet-${DATE}.osh.orc $PLANET_HISTORY_ORC_DIR

--- a/deployment/streaming/scripts/batch-process.sh
+++ b/deployment/streaming/scripts/batch-process.sh
@@ -12,7 +12,7 @@ ARGS=$4
 
 set -x
 aws emr create-cluster \
-  --applications Name=Ganglia Name=Spark \
+  --applications Name=Ganglia Name=Spark Name=Hive \
   --log-uri ${S3_LOG_URI} \
   --configurations "file://scripts/emr-configurations/batch-process.json" \
   --ebs-root-volume-size 10 \


### PR DESCRIPTION
When reconstructing the staging DB, it is necessary to produce an ORC file for the planet history as well as to update a changeset ORC file. The latter was covered by a make rule, but the former task was previously left to a manual process. This PR adds automation to help with this, and combines it with the changeset ORC update. Now, from `./deployment/batch/makefile`, `make prepare-bulk-ingest` will create a cluster and add steps for both the planet history ORC conversion and the changeset ORC update. The cluster will terminate automatically after the steps terminate.

This PR replaces #200 after that PR was soiled by the commit of private information and the tree was never the same.