### PR TITLE
Address NULL user_id entries

### DIFF
--- a/deployment/streaming/Makefile
+++ b/deployment/streaming/Makefile
@@ -12,6 +12,19 @@ else
 	TASK_SUFFIX=-staging
 endif
 DB_URI=${DB_BASE_URI}/${DATABASE}
+ifndef STATS_SNAPSHOT_ORC
+SNAPSHOT_OPT=
+BATCH_WORKERS=64
+else
+ifndef USE_SNAPSHOT
+SNAPSHOT_OPT=, \"--stats-checkpoint\", \"${STATS_SNAPSHOT_ORC}\"
+BATCH_WORKERS=64
+else
+SNAPSHOT_OPT=, \"--stats-checkpoint\", \"${STATS_SNAPSHOT_ORC}\", \"--use-checkpoint\"
+BATCH_WORKERS=1
+endif
+endif
+
 
 .EXPORT_ALL_VARIABLES:
 
@@ -104,5 +117,8 @@ batch-generate-edit-histograms:
 
 batch-generate-db-backfill:
 	BATCH_CORE_INSTANCE_TYPE=r5.xlarge BATCH_MASTER_INSTANCE_TYPE=m4.xlarge ./scripts/batch-process.sh \
-	  "OSMesa Batch Process" "ChangesetStatsCreator" 64 \
-		"[\"spark-submit\", \"--deploy-mode\", \"cluster\", \"--class\", \"osmesa.apps.batch.ChangesetStatsCreator\", \"${OSMESA_APPS_JAR}\", \"--history\", \"${HISTORY_ORC}\", \"--changesets\", \"${CHANGESETS_ORC}\", \"--changeset-stream\", \"${CHANGESET_SOURCE}\", \"--database-url\", \"${DB_URI}\"]"
+	  "OSMesa Batch Process" ${BATCH_WORKERS} \
+		"CopyJarFromS3" \
+		"[\"aws\", \"s3\", \"cp\", \"${OSMESA_APPS_JAR}\", \"/tmp/apps.jar\"]" \
+		"ChangesetStatsCreator" \
+		"[\"spark-submit\", \"--deploy-mode\", \"cluster\", \"--class\", \"osmesa.apps.batch.ChangesetStatsCreator\", \"/tmp/apps.jar\", \"--history\", \"${HISTORY_ORC}\", \"--changesets\", \"${CHANGESETS_ORC}\", \"--changeset-stream\", \"${CHANGESET_SOURCE}\", \"--database-url\", \"${DB_URI}\"${SNAPSHOT_OPT}]"

--- a/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
@@ -155,7 +155,7 @@ object ChangesetMetadataCreator
           .options(csvOpts)
           .load(changesetCSV.toString)
           .select(
-            'id as 'changeset_id,
+            'id cast("Long") as 'changeset_id,
             'created_at as 'createdAt,
             lit(false) as 'open,
             'closed_at as 'closedAt,
@@ -164,7 +164,7 @@ object ChangesetMetadataCreator
             ('max_lat cast("Double")) / 1e7 as 'maxLat,
             ('max_lon cast("Double")) / 1e7 as 'maxLon,
             'num_changes as 'numChanges,
-            'user_id as 'uid
+            'user_id cast("Long") as 'uid
           )
 
         logger.info(s"Loaded ${changesets.count} changesets")

--- a/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
@@ -1,0 +1,174 @@
+import osmesa.apps.batch
+
+import cats.implicits._
+import com.monovore.decline.{CommandApp, Opts}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import osmesa.analytics.Analytics
+import vectorpipe.model.ChangesetComment
+
+import java.net.URI
+
+object ChangesetMetadataCreator
+  extends CommandApp(
+    name = "changeset-metadata",
+    header = "Changeset Metadata",
+    main = {
+
+      val changesetsCSVOpt = Opts.option[URI](
+        "changesets",
+        metavar = "CSV URI",
+        help = "Location of CSV file giving dump of changesets table"
+      )
+
+      val commentsCSVOpt = Opts.option[URI](
+        "comments",
+        metavar = "CSV URI",
+        help = "Location of CSV file giving dump of changeset comments table"
+      )
+
+      val tagsCSVOpt = Opts.option[URI](
+        "tags",
+        metavar = "CSV URI",
+        help = "Location of CSV file giving dump of changeset tags table"
+      )
+
+      val usersCSVOpt = Opts.option[URI](
+        "users",
+        metavar = "users",
+        help = "Location of CSV file giving dump of users table"
+      )
+
+      val outputOrcArg = Opts.argument[URI](
+        metavar = "ORC URI"
+      )
+
+      (changesetsCSVOpt, commentsCSVOpt, tagsCSVOpt, usersCSVOpt, outputOrcArg).mapN {
+        (changesetCSV, commentsCSV, tagsCSV, usersCSV, outputOrc) =>
+
+        import ChangesetMetadataCreatorUtils.{getClass=>_, _}
+
+        implicit val spark: SparkSession = Analytics.sparkSession("ChangesetStats")
+        import spark.implicits._
+
+        val logger = org.apache.log4j.Logger.getLogger(getClass())
+
+        val csvOpts = Map(
+          "header" -> "true",
+          "inferSchema" -> "true",
+          "multiline" -> "true"
+        )
+
+        val users = spark
+          .read
+          .format("csv")
+          .options(csvOpts)
+          .load(usersCSV.toString)
+
+        val tags = spark
+          .read
+          .format("csv")
+          .options(csvOpts)
+          .load(changesetCSV.toString)
+          .groupBy('changeset_id)
+          .agg(
+            'changeset_id,
+            collect_list('k) as 'k,
+            collect_list('v) as 'v
+          ).as[ChangesetTagRaw]
+          .map(_.toChangesetTag)
+
+        val comments = spark
+          .read
+          .format("csv")
+          .options(csvOpts)
+          .load(commentsCSV.toString)
+          .select(
+            'changeset_id cast("Long") as 'changeset_id,
+            'author_id cast("Int") as 'uid,
+            'body,
+            'created_at as 'date
+          ).join(users.withColumnRenamed("id", "uid"), Seq("uid"), "left")
+          .groupBy('changeset_id)
+          .agg(
+            'changeset_id,
+            collect_list('date) as 'dates,
+            collect_list('uid) as 'uids,
+            collect_list('name) as 'users,
+            collect_list('body) as 'bodies
+          ).as[ChangesetCommentRaw].map(_.toChangesetComments)
+
+        val changesets = spark
+          .read
+          .format("csv")
+          .options(csvOpts)
+          .load(changesetCSV.toString)
+          .select(
+            'id as 'changeset_id,
+            'created_at as 'createdAt,
+            lit(false) as 'open,
+            'closed_at as 'closedAt,
+            ('min_lat cast("Double")) / 1e7 as 'minLat,
+            ('min_lon cast("Double")) / 1e7 as 'minLon,
+            ('max_lat cast("Double")) / 1e7 as 'maxLat,
+            ('max_lon cast("Double")) / 1e7 as 'maxLon,
+            'num_changes as 'numChanges,
+            'user_id as 'uid
+          )
+
+        val complete = changesets
+          .join(users.withColumnRenamed("id", "uid"), Seq("uid"), "left")
+          .withColumnRenamed("name", "user")
+          .join(comments, Seq("changeset_id"), "left")
+          .join(tags, Seq("changeset_id"), "left")
+          .withColumnRenamed("changeset_id", "id")
+          .withColumn("sequence", lit(-1))
+
+        complete.repartition(1).write.orc(outputOrc.toString)
+
+        spark.stop
+      }
+    }
+  )
+
+object ChangesetMetadataCreatorUtils {
+
+  case class ChangesetTag(
+    changeset_id: Long,
+    tags: Map[String, String]
+  )
+
+  case class ChangesetTagRaw(
+    changeset_id: String,
+    k: Seq[String],
+    v: Seq[String])
+  {
+    def toChangesetTag(): ChangesetTag = {
+      ChangesetTag(changeset_id.toLong, k.zip(v).toMap)
+    }
+  }
+
+  case class ChangesetCommentWithId(
+    changeset_id: String,
+    commentsCount: Int,
+    comments: Seq[ChangesetComment]
+  )
+
+  case class ChangesetCommentRaw(
+    changeset_id: String,
+    dates: Seq[java.sql.Timestamp],
+    uids: Seq[Int],
+    users: Seq[String],
+    bodies: Seq[String]
+  ) {
+    def toChangesetComments(): ChangesetCommentWithId = {
+      ChangesetCommentWithId(
+        changeset_id,
+        dates.length,
+        for ( i <- Range(0, dates.length).toSeq ) yield
+          ChangesetComment(dates(i), users(i), uids(i), bodies(i))
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
After a bulk ingest, it was noticed that there were changesets which lacked metadata.  This was particularly a problem for users whose stats weren't being accurately counted.  We observed NULL user IDs after a bulk ingest on changesets which had non-zero total edits.  Some of these mis-associations arose from an incomplete metadata source, but others were represented in the metadata ORC and were still missing in the final result.  The implication is that some records were not being correctly committed to the database.

This PR solves the DB commitment problem by wrapping our DB writes in JDBC transactions.  This allows for results to be checked for completeness and rolled back and reattempted in case of trouble.  This was by all accounts successful.

This PR does not fix the problem of missing metadata in the changeset ORC file.

I also adjusted the `batch-process.sh` script to allow multiple steps to be added.  This was necessary as a phantom EMR bug appeared (_**which remains unsolved**_), preventing proper startup of the spark job due to S3 credentials not being available.  We might investigate adding a sleep step to give time for the credentials to materialize (relaunching the initial steps was generally sufficient, but means that the cluster no longer auto-terminates).