### PR TITLE
Changeset metadata ORC improvements

### DIFF
--- a/deployment/batch/makefiles/Makefile
+++ b/deployment/batch/makefiles/Makefile
@@ -53,11 +53,11 @@ create-cluster:
 'Name=Workers,${WORKER_BID_PRICE}InstanceCount=${WORKER_COUNT},InstanceGroupType=CORE,InstanceType=${WORKER_INSTANCE}${EMR_ATTRS_CORE}' \
 | cut -f2 | tee cluster-id.txt
 
-update-changeset-orc:
+create-changeset-orc:
 	aws emr add-steps --output text --cluster-id ${CLUSTER_ID} \
 --steps Type=CUSTOM_JAR,Name="Changeset ORC Update",Jar=command-runner.jar,Args=[\
 spark-submit,--master,yarn,--deploy-mode,cluster,\
---class,osmesa.apps.batch.MergeChangesets,\
+--class,osmesa.apps.batch.ChangesetMetadataCreator,\
 --driver-memory,${DRIVER_MEMORY},\
 --driver-cores,${DRIVER_CORES},\
 --executor-memory,${EXECUTOR_MEMORY},\
@@ -70,8 +70,10 @@ spark-submit,--master,yarn,--deploy-mode,cluster,\
 --conf,spark.shuffle.io.connectionTimeout=18000s,\
 --conf,spark.shuffle.service.enabled=true,\
 ${S3_URI}/${APPS_JAR},\
---changesets=${CHANGESET_URI},\
-${CHANGESET_ORC_SOURCE},\
+--changesets=${CHANGESET_CSV},\
+--comments=${CHANGESET_COMMENTS_CSV},\
+--tags=${CHANGESET_TAGS_CSV},\
+--users=${USERS_CSV},\
 ${CHANGESET_ORC_DEST}\
 ] | cut -f2 | tee last-step-id.txt
 
@@ -94,9 +96,9 @@ prepare-bulk-ingest: upload-apps
 --instance-groups \
 'Name=Master,${MASTER_BID_PRICE}InstanceCount=1,InstanceGroupType=MASTER,InstanceType=${MASTER_INSTANCE}${EMR_ATTRS_MASTER}' \
 'Name=Workers,${WORKER_BID_PRICE}InstanceCount=1,InstanceGroupType=CORE,InstanceType=${WORKER_INSTANCE}${EMR_ATTRS_CORE}' \
---steps Type=CUSTOM_JAR,ActionOnFailure=CONTINUE,Name="History PBF to ORC",Jar=s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar,Args=["${S3_URI}/scripts/latest-history-to-orc.sh"] Type=CUSTOM_JAR,Name="Changeset ORC Update",Jar=command-runner.jar,Args=[\
+--steps Type=CUSTOM_JAR,ActionOnFailure=CONTINUE,Name="History PBF to ORC",Jar=s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar,Args=["${S3_URI}/scripts/latest-history-to-orc.sh"] Type=CUSTOM_JAR,Name="Changeset ORC Generation",Jar=command-runner.jar,Args=[\
 spark-submit,--master,yarn,--deploy-mode,cluster,\
---class,osmesa.apps.batch.MergeChangesets,\
+--class,osmesa.apps.batch.ChangesetMetadataCreator,\
 --driver-memory,${DRIVER_MEMORY},\
 --driver-cores,${DRIVER_CORES},\
 --executor-memory,${EXECUTOR_MEMORY},\
@@ -109,8 +111,10 @@ spark-submit,--master,yarn,--deploy-mode,cluster,\
 --conf,spark.shuffle.io.connectionTimeout=18000s,\
 --conf,spark.shuffle.service.enabled=true,\
 ${S3_URI}/${APPS_JAR},\
---changesets=${CHANGESET_URI},\
-${CHANGESET_ORC_SOURCE},\
+--changesets=${CHANGESET_CSV},\
+--comments=${CHANGESET_COMMENTS_CSV},\
+--tags=${CHANGESET_TAGS_CSV},\
+--users=${USERS_CSV},\
 ${CHANGESET_ORC_DEST}\
 ]  | cut -f2 | tee cluster-id.txt
 

--- a/deployment/batch/makefiles/config-run.mk.template
+++ b/deployment/batch/makefiles/config-run.mk.template
@@ -9,9 +9,11 @@ export OUTPUT_LOCATION := [TARGET_BUCKET]
 export ORC_CACHE_LOCATION := ${S3_URI}/cache
 export VECTORTILE_CATALOG_LOCATION = ${S3_URI}/vectortiles
 
-export CHANGESET_URI := [REPLICATION URL]
-export CHANGESET_ORC_SOURCE := [S3 URI of existing orc]
-export CHANGESET_ORC_DEST := [S3 URI of new orc]
+export CHANGESET_CSV := [URI of OSM CSV table dump]
+export CHANGESET_COMMENTS_CSV := [URI of OSM CSV table dump]
+export CHANGESET_TAGS_CSV := [URI of OSM CSV table dump]
+export USER_CSV := [URI of OSM CSV table dump]
+export CHANGESET_ORC_DEST := [S3 URI of ORC]
 
 export PLANET_HISTORY_PBF := [S3 URI of target planet history PBF]
 export PLANET_HISTORY_ORC_DIR := [S3 URI of converted planet history ORCs]

--- a/deployment/streaming/config-deployment.mk.template
+++ b/deployment/streaming/config-deployment.mk.template
@@ -49,3 +49,9 @@ export CHANGESETS_ORC :=
 
 export FOOTPRINT_VT_LOCATION :=
 export HISTOGRAM_VT_LOCATION :=
+
+# Uncomment the following line to save the processed stats
+# export STATS_SNAPSHOT_ORC :=
+
+# Uncomment the following line to use the above snapshot in lieu of recalculating from history; setting to "no" will not turn feature off
+# export USE_SNAPSHOT := yes

--- a/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
@@ -53,7 +53,7 @@ import java.net.URI
  *
  * users
  *  |-- id: integer (nullable = true)
- *  |-- name: string (nullable = true)
+ *  |-- display_name: string (nullable = true)
  *
  * Invocation:
  *   spark-submit --class osmesa.apps.batch.ChangesetMetadataCreator <jar file> \
@@ -115,6 +115,7 @@ object ChangesetMetadataCreator
           .format("csv")
           .options(csvOpts)
           .load(usersCSV.toString)
+          .select('id, 'display_name as 'name)
 
         val tags = spark
           .read


### PR DESCRIPTION
This PR adds some infrastructure to the batch makefiles to allow for the easy creation of a changeset metadata ORC from CSV exports from an OSM database.