### PR TITLE
Update augdiff tasks to match deployment

### DIFF
--- a/deployment/streaming/Makefile
+++ b/deployment/streaming/Makefile
@@ -70,8 +70,8 @@ define-production-streaming-update-tasks:
 deploy-streaming-augdiff-producer:
 	aws ecs create-service \
 	  --cluster "${ECS_CLUSTER}" \
-	  --service-name "overpass-diff-publisher" \
-	  --task-definition "overpass-diff-publisher" \
+	  --service-name "${AUGDIFF_SERVICE_NAME}" \
+	  --task-definition "${AUGDIFF_SERVICE_NAME}" \
 	  --desired-count 1 \
 	  --launch-type FARGATE \
 	  --scheduling-strategy REPLICA \

--- a/deployment/streaming/config-deployment.mk.template
+++ b/deployment/streaming/config-deployment.mk.template
@@ -18,9 +18,11 @@ export ECS_SECURITY_GROUP :=
 export CLUSTER_NAME_DEPLOYMENT :=
 export CLUSTER_NAME_STAGING :=
 
+export AUGDIFF_SERVICE_NAME := "azavea-overpass-diff-publisher"
 export AUGDIFF_ECR_IMAGE :=
 export AUGDIFF_SOURCE :=
-export OVERPASS_URI :=
+export ONRAMP_URL :=
+export OVERPASS_URL :=
 export CHANGESET_SOURCE :=
 export CHANGE_SOURCE :=
 

--- a/deployment/streaming/scripts/define-streaming-augdiff-producer.sh
+++ b/deployment/streaming/scripts/define-streaming-augdiff-producer.sh
@@ -6,7 +6,7 @@ if [ -z ${VERSION_TAG+x} ]; then
 fi
 
 aws ecs register-task-definition \
-    --family overpass-diff-publisher \
+    --family "${AUGDIFF_SERVICE_NAME}" \
     --task-role-arn "arn:aws:iam::${IAM_ACCOUNT}:role/ECSTaskS3" \
     --execution-role-arn "arn:aws:iam::${IAM_ACCOUNT}:role/ecsTaskExecutionRole" \
     --network-mode awsvpc \
@@ -29,10 +29,14 @@ aws ecs register-task-definition \
 	      \"environment\": [
 	        {
 	          \"name\": \"OVERPASS_URL\",
-	          \"value\": \"${OVERPASS_URI}\"
+	          \"value\": \"${OVERPASS_URL}\"
+	        },
+	        {
+	          \"name\": \"ONRAMP_URL\",
+	          \"value\": \"${ONRAMP_URL}\"
 	        }
 	      ],
 	      \"image\": \"${AUGDIFF_ECR_IMAGE}\",
-	      \"name\": \"overpass-augdiff-publisher-${VERSION_TAG}\"
+	      \"name\": \"${AUGDIFF_SERVICE_NAME}\"
 	    }
 	  ]"


### PR DESCRIPTION
- Now use the correct azavea-overpass-diff-publisher
  task definitions (since we switched to azavea fork
  of the repo)
- Support deployments using Onramp

I tested this in our staging and production environment by setting the appropriate config-deployment.mk variables and running the define then deploy tasks. 