### PR TITLE
Handle changeset metadata tags with quoted strings

### DIFF
--- a/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
+++ b/src/apps/src/main/scala/osmesa/apps/batch/ChangesetMetadataCreator.scala
@@ -107,7 +107,9 @@ object ChangesetMetadataCreator
         val csvOpts = Map(
           "header" -> "true",
           "inferSchema" -> "true",
-          "multiline" -> "true"
+          "multiline" -> "true",
+          "quote" -> "\"",
+          "escape" -> "\""
         )
 
         val users = spark


### PR DESCRIPTION
We encountered tags in the changeset metadata collection that buggered the `ChangesetMetadataCreator` batch job.  This was because we had values with commas for the first time, and we had not configured the Spark CSV reader to handle these properly.  Adding `"quote" -> "\""` and `"escape" -> "\""` to the reader options as described [here](https://stackoverflow.com/questions/40413526/reading-csv-files-with-quoted-fields-containing-embedded-commas) fixes the problem.